### PR TITLE
allow Asset with TransferFeeConfig when fee_bps is 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ target
 node_modules
 test-ledger
 .yarn
+.agents
+.claude
+skills-lock.json

--- a/integration-tests/src/async_vault/create_deposit_request.rs
+++ b/integration-tests/src/async_vault/create_deposit_request.rs
@@ -7,12 +7,15 @@ use async_vault_client::{
 };
 use litesvm::LiteSVM;
 use solana_sdk::{
-    account::ReadableAccount, clock::Clock, pubkey::Pubkey, signature::Keypair, signer::Signer, transaction::Transaction
+    account::ReadableAccount, clock::Clock, pubkey::Pubkey, signature::Keypair, signer::Signer,
+    transaction::Transaction,
 };
 use test_case::test_case;
 
 use crate::helper_functions::{
-    PENDING_VAULT_SEED, RESERVE_CONFIG_SEED, VAULT_CONFIG_SEED, assert_error_code, create_async_vault, create_ata, create_deposit_request_ix, create_mint, get_token_account_amount, helper_mint_to, initialize_async_vault, set_up_async_vault, update_vault_nav
+    assert_error_code, create_async_vault, create_ata, create_deposit_request_ix, create_mint,
+    get_token_account_amount, helper_mint_to, initialize_async_vault, set_up_async_vault,
+    update_vault_nav, PENDING_VAULT_SEED, RESERVE_CONFIG_SEED, VAULT_CONFIG_SEED,
 };
 
 #[test_case(1_000_000, false ; "deposit request succeeds")]
@@ -329,7 +332,6 @@ fn test_create_deposit_request_fails(asset_transfer_fee: Option<u16>, expected_e
 
     // Update TransferFee to nonzero after vault creation
     if let Some(fee_bps) = asset_transfer_fee {
-        println!("HERE!");
         let set_fee_ix =
             token_2022::spl_token_2022::extension::transfer_fee::instruction::set_transfer_fee(
                 &token_2022::ID,
@@ -383,8 +385,6 @@ fn test_create_deposit_request_fails(asset_transfer_fee: Option<u16>, expected_e
         blockhash,
     );
 
-    let res = svm.send_transaction(tx);
-    println!("RES: {:#?}", res);
-    // .err().unwrap();
-    assert_error_code(&res.err().unwrap(), expected_error_code, "Incorrect error code"); 
+    let res = svm.send_transaction(tx).err().unwrap();
+    assert_error_code(&res, expected_error_code, "Incorrect error code");
 }

--- a/integration-tests/src/async_vault/create_deposit_request.rs
+++ b/integration-tests/src/async_vault/create_deposit_request.rs
@@ -1,19 +1,18 @@
-use anchor_spl::{associated_token::get_associated_token_address_with_program_id, token};
+use anchor_spl::{
+    associated_token::get_associated_token_address_with_program_id, token, token_2022,
+};
 use async_vault_client::{
     sdk::{program_id, IntoSdkInstruction},
     CreateDepositRequestBuilder, Request, RequestState, RequestType,
 };
 use litesvm::LiteSVM;
 use solana_sdk::{
-    account::ReadableAccount, pubkey::Pubkey, signature::Keypair, signer::Signer,
-    transaction::Transaction,
+    account::ReadableAccount, clock::Clock, pubkey::Pubkey, signature::Keypair, signer::Signer, transaction::Transaction
 };
 use test_case::test_case;
 
 use crate::helper_functions::{
-    create_async_vault, create_ata, create_deposit_request_ix, create_mint,
-    get_token_account_amount, helper_mint_to, initialize_async_vault, set_up_async_vault,
-    update_vault_nav, PENDING_VAULT_SEED, RESERVE_CONFIG_SEED, VAULT_CONFIG_SEED,
+    PENDING_VAULT_SEED, RESERVE_CONFIG_SEED, VAULT_CONFIG_SEED, assert_error_code, create_async_vault, create_ata, create_deposit_request_ix, create_mint, get_token_account_amount, helper_mint_to, initialize_async_vault, set_up_async_vault, update_vault_nav
 };
 
 #[test_case(1_000_000, false ; "deposit request succeeds")]
@@ -38,7 +37,14 @@ fn test_create_deposit_request(deposit_amount: u64, with_operator: bool) {
         vault_pubkey,
         pending_vault_pubkey,
         fee_recipient_ata,
-    ) = set_up_async_vault(&mut svm, token::ID, token::ID, user_amount, 100_000_000);
+    ) = set_up_async_vault(
+        &mut svm,
+        token::ID,
+        None,
+        token::ID,
+        user_amount,
+        100_000_000,
+    );
 
     let user_token_account = get_associated_token_address_with_program_id(
         &user.pubkey(),
@@ -290,4 +296,95 @@ fn test_multiple_deposit_requests_with_unique_keypairs() {
         get_token_account_amount(&svm.get_account(&pending_vault_pubkey).unwrap()),
         deposit_amount * 2
     );
+}
+
+#[test_case(Some(1), 6016 ; "deposit_request_with_nonzero_transfer_fee_fails")]
+fn test_create_deposit_request_fails(asset_transfer_fee: Option<u16>, expected_error_code: u32) {
+    let mut svm = LiteSVM::new();
+    let program_bytes = include_bytes!("../../../target/deploy/async_vault.so");
+    svm.add_program(program_id(), program_bytes).unwrap();
+
+    let user_amount = 1_000_000_000;
+    let (
+        _authority,
+        _payer,
+        mint_authority,
+        asset_mint,
+        share_mint,
+        user,
+        _operator,
+        _fee_recipient,
+        _reserve_pubkey,
+        vault_pubkey,
+        pending_vault_pubkey,
+        _fee_recipient_ata,
+    ) = set_up_async_vault(
+        &mut svm,
+        token_2022::ID,
+        Some(0), // Must start with TransferFee of 0 to create the Vault
+        token::ID,
+        user_amount,
+        100_000_000,
+    );
+
+    // Update TransferFee to nonzero after vault creation
+    if let Some(fee_bps) = asset_transfer_fee {
+        println!("HERE!");
+        let set_fee_ix =
+            token_2022::spl_token_2022::extension::transfer_fee::instruction::set_transfer_fee(
+                &token_2022::ID,
+                &asset_mint.pubkey(),
+                &mint_authority.pubkey(),
+                &[],
+                fee_bps,
+                u64::MAX,
+            )
+            .unwrap();
+
+        let tx = Transaction::new_signed_with_payer(
+            &[set_fee_ix],
+            Some(&mint_authority.pubkey()),
+            &[&mint_authority],
+            svm.latest_blockhash(),
+        );
+        svm.send_transaction(tx)
+            .expect("set_transfer_fee should succeed");
+
+        // Advance clock by 2 epoch to ensure TransferFeeconfig change takes effect.
+        let mut clock = svm.get_sysvar::<Clock>();
+        clock.epoch += 2;
+        svm.set_sysvar(&clock);
+    }
+
+    let user_token_account = get_associated_token_address_with_program_id(
+        &user.pubkey(),
+        &asset_mint.pubkey(),
+        &token_2022::ID,
+    );
+    let request_keypair = Keypair::new();
+
+    let ix = CreateDepositRequestBuilder::new()
+        .user(user.pubkey())
+        .asset_mint(asset_mint.pubkey())
+        .share_mint(share_mint.pubkey())
+        .request(request_keypair.pubkey())
+        .vault(vault_pubkey)
+        .user_token_account(user_token_account)
+        .pending_vault(pending_vault_pubkey)
+        .asset_token_program(token_2022::ID)
+        .amount(1_000_000)
+        .instruction();
+
+    let blockhash = svm.latest_blockhash();
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&user.pubkey()),
+        &[user, request_keypair],
+        blockhash,
+    );
+
+    let res = svm.send_transaction(tx);
+    println!("RES: {:#?}", res);
+    // .err().unwrap();
+    assert_error_code(&res.err().unwrap(), expected_error_code, "Incorrect error code"); 
 }

--- a/integration-tests/src/async_vault/create_vault.rs
+++ b/integration-tests/src/async_vault/create_vault.rs
@@ -11,23 +11,23 @@ use solana_sdk::{
 use test_case::test_case;
 
 use crate::helper_functions::{
-    assert_error_code, create_async_vault, create_mint, PENDING_VAULT_SEED, RESERVE_CONFIG_SEED,
-    VAULT_CONFIG_SEED,
+    PENDING_VAULT_SEED, RESERVE_CONFIG_SEED, VAULT_CONFIG_SEED, assert_error_code, create_async_vault, create_mint, create_mint_with_transfer_fee
 };
 
-#[test_case(100_000_000, true, true, true, false, token::ID,token::ID ; "both async inflows and outflows")]
-#[test_case(100_000_000, true, true, true, false, token_2022::ID,token_2022::ID ; "Token 2022 program for both mints")]
-#[test_case(100_000_000, true, true, true, false, token::ID,token_2022::ID ; "Token program for asset, Token program 2022 for share")]
-#[test_case(100_000_000, true, true, true, false, token::ID,token_2022::ID ; "Token 2022 program for asset, Token program for share")]
-#[test_case(100_000_000, true, false, true, false,token_2022::ID,token_2022::ID ; "async inflows only")]
-#[test_case(100_000_000, false, true, true, false,token_2022::ID,token_2022::ID ; "async outflows only")]
-#[test_case(100_000_000, false, false, true, false,token_2022::ID,token_2022::ID ; "no async flows")]
-#[test_case(1, true, true, true, false,token_2022::ID,token_2022::ID ; "minimum price")]
-#[test_case(u64::MAX, true, true, true,  false,token_2022::ID,token_2022::ID ; "maximum price")]
-#[test_case(0, true, true, true,  false,token_2022::ID,token_2022::ID ; "zero initial price fails")]
-#[test_case(100_000_000, true, true, false, false,token_2022::ID,token_2022::ID ; "invalid mint authority fails")]
-#[test_case(100_000_000, true, true, true,  false,token_2022::ID,token_2022::ID ; "duplicate vault creation fails")]
-#[test_case(100_000_000, true, true, true,  true, token_2022::ID,token_2022::ID; "same mints fails")]
+#[test_case(100_000_000, true, true, true, false, token::ID,token::ID, 0 ; "both async inflows and outflows")]
+#[test_case(100_000_000, true, true, true, false, token_2022::ID,token_2022::ID, 0 ; "Token 2022 program for both mints")]
+#[test_case(100_000_000, true, true, true, false, token::ID,token_2022::ID, 0 ; "Token program for asset, Token program 2022 for share")]
+#[test_case(100_000_000, true, true, true, false, token::ID,token_2022::ID, 0 ; "Token 2022 program for asset, Token program for share")]
+#[test_case(100_000_000, true, false, true, false,token_2022::ID,token_2022::ID, 0 ; "async inflows only")]
+#[test_case(100_000_000, false, true, true, false,token_2022::ID,token_2022::ID, 0 ; "async outflows only")]
+#[test_case(100_000_000, false, false, true, false,token_2022::ID,token_2022::ID, 0 ; "no async flows")]
+#[test_case(1, true, true, true, false,token_2022::ID,token_2022::ID, 0 ; "minimum price")]
+#[test_case(u64::MAX, true, true, true,  false,token_2022::ID,token_2022::ID, 0 ; "maximum price")]
+#[test_case(0, true, true, true,  false,token_2022::ID,token_2022::ID, 0 ; "zero initial price fails")]
+#[test_case(100_000_000, true, true, false, false,token_2022::ID,token_2022::ID, 0 ; "invalid mint authority fails")]
+#[test_case(100_000_000, true, true, true,  false,token_2022::ID,token_2022::ID, 0 ; "duplicate vault creation fails")]
+#[test_case(100_000_000, true, true, true,  true, token_2022::ID,token_2022::ID, 0 ; "same mints fails")]
+#[test_case(100_000_000, true, true, true,  false, token_2022::ID,token_2022::ID, 1 ; "nonzero transfer fee asset mint fails")]
 fn test_create_vault(
     initial_price: u64,
     async_inflows: bool,
@@ -36,6 +36,7 @@ fn test_create_vault(
     use_same_mints: bool,
     asset_program: Pubkey,
     share_program: Pubkey,
+    asset_transfer_fee: u16,
 ) {
     let mut svm = LiteSVM::new();
 
@@ -58,7 +59,11 @@ fn test_create_vault(
     svm.airdrop(&fake_mint_authority.pubkey(), 1_000_000_000)
         .unwrap();
 
-    create_mint(&mut svm, &mint_authority, &asset_mint, &asset_program);
+    if asset_program == token_2022::ID {
+        create_mint_with_transfer_fee(&mut svm, &mint_authority, &asset_mint, asset_transfer_fee, u64::MAX);
+    } else {
+        create_mint(&mut svm, &mint_authority, &asset_mint, &asset_program);
+    }
     if !use_same_mints {
         create_mint(&mut svm, &mint_authority, &share_mint, &share_program);
     }
@@ -106,7 +111,7 @@ fn test_create_vault(
         share_program,
     );
 
-    let should_succeed = initial_price != 0 && use_valid_mint_authority && !use_same_mints;
+    let should_succeed = initial_price != 0 && use_valid_mint_authority && !use_same_mints && asset_transfer_fee == 0;
 
     if should_succeed {
         result.expect("async vault creation should succeed");
@@ -142,6 +147,9 @@ fn test_create_vault(
 
         if use_same_mints {
             assert_error_code(err_result, 6010, "Mints should be different.");
+        }
+        if asset_transfer_fee > 0 {
+            assert_error_code(err_result, 6016, "Nonzero transfer fee should fail");
         }
     }
 }
@@ -238,3 +246,4 @@ fn test_create_vault_nonzero_share_mint_supply_fails() {
     let err_result = &result.unwrap_err();
     assert_error_code(err_result, 6011, "Share mint supply should be zero.");
 }
+

--- a/integration-tests/src/async_vault/create_vault.rs
+++ b/integration-tests/src/async_vault/create_vault.rs
@@ -11,7 +11,8 @@ use solana_sdk::{
 use test_case::test_case;
 
 use crate::helper_functions::{
-    PENDING_VAULT_SEED, RESERVE_CONFIG_SEED, VAULT_CONFIG_SEED, assert_error_code, create_async_vault, create_mint, create_mint_with_transfer_fee
+    assert_error_code, create_async_vault, create_mint, create_mint_with_transfer_fee,
+    PENDING_VAULT_SEED, RESERVE_CONFIG_SEED, VAULT_CONFIG_SEED,
 };
 
 #[test_case(100_000_000, true, true, true, false, token::ID,token::ID, 0 ; "both async inflows and outflows")]
@@ -60,7 +61,13 @@ fn test_create_vault(
         .unwrap();
 
     if asset_program == token_2022::ID {
-        create_mint_with_transfer_fee(&mut svm, &mint_authority, &asset_mint, asset_transfer_fee, u64::MAX);
+        create_mint_with_transfer_fee(
+            &mut svm,
+            &mint_authority,
+            &asset_mint,
+            asset_transfer_fee,
+            u64::MAX,
+        );
     } else {
         create_mint(&mut svm, &mint_authority, &asset_mint, &asset_program);
     }
@@ -111,7 +118,10 @@ fn test_create_vault(
         share_program,
     );
 
-    let should_succeed = initial_price != 0 && use_valid_mint_authority && !use_same_mints && asset_transfer_fee == 0;
+    let should_succeed = initial_price != 0
+        && use_valid_mint_authority
+        && !use_same_mints
+        && asset_transfer_fee == 0;
 
     if should_succeed {
         result.expect("async vault creation should succeed");
@@ -246,4 +256,3 @@ fn test_create_vault_nonzero_share_mint_supply_fails() {
     let err_result = &result.unwrap_err();
     assert_error_code(err_result, 6011, "Share mint supply should be zero.");
 }
-

--- a/integration-tests/src/async_vault/create_vault.rs
+++ b/integration-tests/src/async_vault/create_vault.rs
@@ -159,7 +159,7 @@ fn test_create_vault(
             assert_error_code(err_result, 6010, "Mints should be different.");
         }
         if asset_transfer_fee > 0 {
-            assert_error_code(err_result, 6016, "Nonzero transfer fee should fail");
+            assert_error_code(err_result, 6016, "Asset mint has invalid extensions.");
         }
     }
 }

--- a/integration-tests/src/async_vault/create_vault.rs
+++ b/integration-tests/src/async_vault/create_vault.rs
@@ -18,7 +18,7 @@ use crate::helper_functions::{
 #[test_case(100_000_000, true, true, true, false, token::ID,token::ID, 0 ; "both async inflows and outflows")]
 #[test_case(100_000_000, true, true, true, false, token_2022::ID,token_2022::ID, 0 ; "Token 2022 program for both mints")]
 #[test_case(100_000_000, true, true, true, false, token::ID,token_2022::ID, 0 ; "Token program for asset, Token program 2022 for share")]
-#[test_case(100_000_000, true, true, true, false, token::ID,token_2022::ID, 0 ; "Token 2022 program for asset, Token program for share")]
+#[test_case(100_000_000, true, true, true, false, token_2022::ID,token::ID, 0 ; "Token 2022 program for asset, Token program for share")]
 #[test_case(100_000_000, true, false, true, false,token_2022::ID,token_2022::ID, 0 ; "async inflows only")]
 #[test_case(100_000_000, false, true, true, false,token_2022::ID,token_2022::ID, 0 ; "async outflows only")]
 #[test_case(100_000_000, false, false, true, false,token_2022::ID,token_2022::ID, 0 ; "no async flows")]

--- a/integration-tests/src/async_vault/set_operator.rs
+++ b/integration-tests/src/async_vault/set_operator.rs
@@ -25,7 +25,14 @@ fn test_set_operator_succeeds() {
         vault_pubkey,
         pending_vault_pubkey,
         _fee_recipient_ata,
-    ) = set_up_async_vault(&mut svm, token::ID, token::ID, 1_000_000_000, 100_000_000);
+    ) = set_up_async_vault(
+        &mut svm,
+        token::ID,
+        None,
+        token::ID,
+        1_000_000_000,
+        100_000_000,
+    );
 
     let user_token_account = get_associated_token_address_with_program_id(
         &user.pubkey(),

--- a/integration-tests/src/async_vault/update_vault_nav.rs
+++ b/integration-tests/src/async_vault/update_vault_nav.rs
@@ -28,7 +28,14 @@ fn test_update_vault_nav(updated_nav: u128) {
         vault_pubkey,
         _pending_vault_pubkey,
         _fee_recipient_ata,
-    ) = set_up_async_vault(&mut svm, token::ID, token::ID, 1_000_000_000, 100_000_000);
+    ) = set_up_async_vault(
+        &mut svm,
+        token::ID,
+        None,
+        token::ID,
+        1_000_000_000,
+        100_000_000,
+    );
 
     let vault_before = Vault::from_bytes(
         svm.get_account(&vault_pubkey)

--- a/integration-tests/src/helper_functions.rs
+++ b/integration-tests/src/helper_functions.rs
@@ -1164,7 +1164,6 @@ pub fn invite_new_authority(
         .new_authority(new_authority)
         .instruction()
         .into_sdk_instruction();
-    let blockhash = svm.latest_blockhash();
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&authority.pubkey()),
@@ -1187,7 +1186,6 @@ pub fn update_vault_nav(
         .instruction()
         .into_sdk_instruction();
 
-    let blockhash = svm.latest_blockhash();
     let tx = Transaction::new_signed_with_payer(
         &[ix],
         Some(&authority.pubkey()),
@@ -1221,6 +1219,7 @@ pub fn accept_authority_invitation(
 pub fn set_up_async_vault(
     svm: &mut LiteSVM,
     asset_token_program: Pubkey,
+    asset_mint_transfer_fee_bps: Option<u16>,
     share_token_program: Pubkey,
     user_amount: u64,
     initial_price: u64,
@@ -1255,7 +1254,18 @@ pub fn set_up_async_vault(
     svm.airdrop(&user.pubkey(), 1_000_000_000).unwrap();
     svm.airdrop(&operator.pubkey(), 1_000_000_000).unwrap();
 
-    create_mint(svm, &mint_authority, &asset_mint, &asset_token_program);
+    if asset_token_program == token_2022::ID && asset_mint_transfer_fee_bps.is_some() {
+        // Initialize with TransferFee extension enabled
+        create_mint_with_transfer_fee(
+            svm,
+            &mint_authority,
+            &asset_mint,
+            asset_mint_transfer_fee_bps.unwrap(),
+            u64::MAX,
+        );
+    } else {
+        create_mint(svm, &mint_authority, &asset_mint, &asset_token_program);
+    }
     create_mint(svm, &mint_authority, &share_mint, &share_token_program);
 
     let (reserve_pubkey, _) = Pubkey::find_program_address(

--- a/programs/async_vault/src/error.rs
+++ b/programs/async_vault/src/error.rs
@@ -34,4 +34,6 @@ pub enum AsyncVaultError {
     MissingFeeRecipient,
     #[msg("Fee recipient account is invalid.")]
     InvalidFeeRecipient,
+    #[msg("Asset mint has invalid extensions.")]
+    InvalidAssetMintExtensions,
 }

--- a/programs/async_vault/src/instructions/create_deposit_request.rs
+++ b/programs/async_vault/src/instructions/create_deposit_request.rs
@@ -1,12 +1,9 @@
-use crate::{error::AsyncVaultError, extensions::get_deposit_fee};
-use anchor_lang::prelude::*;
-use anchor_spl::{
-    token_2022::spl_token_2022::{
-        self,
-        extension::{BaseStateWithExtensions, StateWithExtensions},
-    },
-    token_interface::{self, Mint, TokenAccount, TokenInterface, TransferChecked},
+use crate::{
+    error::AsyncVaultError, extensions::get_deposit_fee,
+    utils::validate_asset_mint_extensions_from_acct_info,
 };
+use anchor_lang::prelude::*;
+use anchor_spl::token_interface::{self, Mint, TokenAccount, TokenInterface, TransferChecked};
 use vault_common::VaultProgramError;
 
 use crate::state::{Request, RequestState, RequestType, Vault, VAULT_CONFIG_SEED};
@@ -90,22 +87,6 @@ impl<'info> CreateDepositRequest<'info> {
             token_interface::transfer_checked(cpi_ctx, amount, self.asset_mint.decimals)
         }
     }
-
-    pub fn assert_no_transfer_fees(&mut self) -> Result<()> {
-        let binding = self.asset_mint.to_account_info();
-        let mint_data = binding
-            .data
-            .try_borrow()
-            .map_err(|_| ProgramError::AccountBorrowFailed)?;
-        let mint = StateWithExtensions::<spl_token_2022::state::Mint>::unpack(&mint_data)?;
-
-        let result =
-            mint.get_extension::<spl_token_2022::extension::transfer_fee::TransferFeeConfig>();
-        if result.is_err() {
-            return Ok(());
-        }
-        return Err(VaultProgramError::TransferFeesAreNotAllowed.into());
-    }
 }
 pub fn handler<'info>(
     ctx: Context<'_, '_, '_, 'info, CreateDepositRequest<'info>>,
@@ -117,7 +98,8 @@ pub fn handler<'info>(
         VaultProgramError::AsyncInflowsDisabled
     );
     require!(ctx.accounts.vault.nav > 0, VaultProgramError::NavIsNotSet);
-    ctx.accounts.assert_no_transfer_fees()?;
+
+    validate_asset_mint_extensions_from_acct_info(&ctx.accounts.asset_mint.to_account_info())?;
 
     ctx.accounts.transfer_asset_token(
         ctx.accounts.user_token_account.to_account_info(),

--- a/programs/async_vault/src/instructions/create_vault.rs
+++ b/programs/async_vault/src/instructions/create_vault.rs
@@ -7,6 +7,7 @@ use anchor_spl::{
 use crate::{
     error::AsyncVaultError,
     state::{Vault, PENDING_VAULT_SEED, RESERVE_CONFIG_SEED, VAULT_CONFIG_SEED},
+    utils::validate_asset_mint_extensions_from_acct_info,
 };
 
 #[derive(AnchorDeserialize, AnchorSerialize)]
@@ -90,7 +91,7 @@ impl<'info> CreateVault<'info> {
 /// Transfers the share mint authority to the vault PDA so only the
 /// program can mint/burn share tokens.
 ///
-/// The vault starts `paused = true` and `initialized = false`; call
+/// The vault starts `initialized = false`; call
 /// `initialize_vault` after configuring extensions to activate it.
 /// Freeze authority is not transferred since is up to the implementator to manage it.
 pub fn handler(ctx: Context<CreateVault>, args: AsyncVaultArgs) -> Result<()> {
@@ -102,6 +103,8 @@ pub fn handler(ctx: Context<CreateVault>, args: AsyncVaultArgs) -> Result<()> {
         ctx.accounts.share_mint.supply == 0,
         AsyncVaultError::ShareMintSupplyShouldBeZero
     );
+
+    validate_asset_mint_extensions_from_acct_info(&ctx.accounts.asset_mint.to_account_info())?;
 
     ctx.accounts.set_new_authority(ctx.accounts.vault.key())?;
 

--- a/programs/async_vault/src/lib.rs
+++ b/programs/async_vault/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod extensions;
 pub mod instructions;
 pub mod state;
+pub mod utils;
 
 use instructions::*;
 

--- a/programs/async_vault/src/state/async_vault.rs
+++ b/programs/async_vault/src/state/async_vault.rs
@@ -1,10 +1,7 @@
 use anchor_lang::prelude::*;
-use vault_common::{FeeType, VaultProgramError};
+use vault_common::VaultProgramError;
 
-use crate::{
-    error::AsyncVaultError,
-    extensions::{self, ExtensionType},
-};
+use crate::error::AsyncVaultError;
 
 #[account]
 #[derive(InitSpace)]

--- a/programs/async_vault/src/utils.rs
+++ b/programs/async_vault/src/utils.rs
@@ -1,0 +1,39 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token_2022::spl_token_2022::{
+    self,
+    extension::{BaseStateWithExtensions, StateWithExtensions},
+};
+
+use crate::error::AsyncVaultError;
+
+/// Validates the extensions on the asset mint to ensure compatibility with the
+/// Async Vault program. This is checked during Vault Creation and Deposit/DepositRequest.
+/// - TransferFeeConfig can be enabled, but must be 0. Many stablecoins have
+/// TransferFeeConfig enabled with a 0 fee, so this is important to support.
+pub fn validate_asset_mint_extensions_from_acct_info(mint_acct: &AccountInfo) -> Result<()> {
+    if mint_acct.owner != &spl_token_2022::ID {
+        return Ok(());
+    }
+    let mint_data = mint_acct.try_borrow_data()?;
+    let mint = StateWithExtensions::<spl_token_2022::state::Mint>::unpack(&mint_data)?;
+
+    // Validate: Mint has 0 transfer fees
+    if let Ok(transfer_fee_config) =
+        mint.get_extension::<spl_token_2022::extension::transfer_fee::TransferFeeConfig>()
+    {
+      msg!("Validating TransferFeeConfig extension on asset mint {:?}", transfer_fee_config);
+        let clock = Clock::get()?;
+        let transfer_fee_bps = u16::from_le_bytes(
+            transfer_fee_config
+                .get_epoch_fee(clock.epoch)
+                .transfer_fee_basis_points
+                .0,
+        );
+        msg!("Found transfer fee bps: {}", transfer_fee_bps);
+        if transfer_fee_bps != 0 {
+            return Err(AsyncVaultError::InvalidAssetMintExtensions.into());
+        }
+    }
+
+    Ok(())
+}

--- a/programs/async_vault/src/utils.rs
+++ b/programs/async_vault/src/utils.rs
@@ -21,7 +21,6 @@ pub fn validate_asset_mint_extensions_from_acct_info(mint_acct: &AccountInfo) ->
     if let Ok(transfer_fee_config) =
         mint.get_extension::<spl_token_2022::extension::transfer_fee::TransferFeeConfig>()
     {
-      msg!("Validating TransferFeeConfig extension on asset mint {:?}", transfer_fee_config);
         let clock = Clock::get()?;
         let transfer_fee_bps = u16::from_le_bytes(
             transfer_fee_config
@@ -29,7 +28,6 @@ pub fn validate_asset_mint_extensions_from_acct_info(mint_acct: &AccountInfo) ->
                 .transfer_fee_basis_points
                 .0,
         );
-        msg!("Found transfer fee bps: {}", transfer_fee_bps);
         if transfer_fee_bps != 0 {
             return Err(AsyncVaultError::InvalidAssetMintExtensions.into());
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault and deposit request creation now validate asset mints and reject assets with non‑zero Token‑2022 transfer fees.

* **Bug Fixes**
  * Added explicit error reporting when asset mints include unsupported or invalid extensions.

* **Tests**
  * New and updated integration tests cover vault/deposit flows with Token‑2022 transfer fees and related setup changes.

* **Chores**
  * Git ignore list updated to exclude additional local files/directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->