### PR TITLE
fix: check asset mint in deposit request

### DIFF
--- a/programs/async_vault/src/error.rs
+++ b/programs/async_vault/src/error.rs
@@ -36,4 +36,8 @@ pub enum AsyncVaultError {
     InvalidFeeRecipient,
     #[msg("Asset mint has invalid extensions.")]
     InvalidAssetMintExtensions,
+    #[msg("Asset mint is not valid.")]
+    InvalidAssetMint,
+    #[msg("Share mint is not valid.")]
+    InvalidShareMint,
 }

--- a/programs/async_vault/src/instructions/create_deposit_request.rs
+++ b/programs/async_vault/src/instructions/create_deposit_request.rs
@@ -32,7 +32,9 @@ pub struct CreateDepositRequest<'info> {
     #[account(
         mut,
         seeds = [VAULT_CONFIG_SEED, share_mint.key().as_ref()],
-        bump
+        bump,
+        has_one = asset_mint @ AsyncVaultError::InvalidAssetMint,
+        has_one = share_mint @ AsyncVaultError::InvalidShareMint,
     )]
     pub vault: Account<'info, Vault>,
 

--- a/programs/async_vault/src/instructions/create_vault.rs
+++ b/programs/async_vault/src/instructions/create_vault.rs
@@ -109,8 +109,8 @@ pub fn handler(ctx: Context<CreateVault>, args: AsyncVaultArgs) -> Result<()> {
     ctx.accounts.set_new_authority(ctx.accounts.vault.key())?;
 
     ctx.accounts.vault.set_inner(Vault {
-        asset_mint_address: ctx.accounts.asset_mint.key(),
-        share_mint_address: ctx.accounts.share_mint.key(),
+        asset_mint: ctx.accounts.asset_mint.key(),
+        share_mint: ctx.accounts.share_mint.key(),
         vault_token_account: ctx.accounts.reserve.key(),
         authority: args.authority,
         fee_recipient: args.fee_recipient,

--- a/programs/async_vault/src/state/async_vault.rs
+++ b/programs/async_vault/src/state/async_vault.rs
@@ -6,9 +6,9 @@ use crate::error::AsyncVaultError;
 #[account]
 #[derive(InitSpace)]
 pub struct Vault {
-    pub asset_mint_address: Pubkey,
+    pub asset_mint: Pubkey,
     /// share mint address
-    pub share_mint_address: Pubkey,
+    pub share_mint: Pubkey,
     /// token account holding confirmed vault assets
     pub vault_token_account: Pubkey,
     /// authority that can sign permissioned instructions
@@ -77,8 +77,8 @@ mod tests {
 
     fn vault_with_nav(nav: u128) -> Vault {
         Vault {
-            asset_mint_address: Pubkey::default(),
-            share_mint_address: Pubkey::default(),
+            asset_mint: Pubkey::default(),
+            share_mint: Pubkey::default(),
             vault_token_account: Pubkey::default(),
             authority: Pubkey::default(),
             fee_recipient: Pubkey::default(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation during deposit request creation to ensure asset and share mint accounts are correctly associated with the vault, preventing transaction failures from account mismatches.

* **Chores**
  * Refactored internal vault account structure with improved field naming for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->