### PR TITLE
update vault accepts fee_recipient

### DIFF
--- a/clients/rust/async_vault/src/generated/instructions/update_vault.rs
+++ b/clients/rust/async_vault/src/generated/instructions/update_vault.rs
@@ -80,7 +80,8 @@ impl Default for UpdateVaultInstructionData {
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateVaultInstructionArgs {
-    pub paused: bool,
+    pub paused: Option<bool>,
+    pub fee_recipient: Option<solana_pubkey::Pubkey>,
 }
 
 impl UpdateVaultInstructionArgs {
@@ -102,6 +103,7 @@ pub struct UpdateVaultBuilder {
     share_mint: Option<solana_pubkey::Pubkey>,
     vault: Option<solana_pubkey::Pubkey>,
     paused: Option<bool>,
+    fee_recipient: Option<solana_pubkey::Pubkey>,
     __remaining_accounts: Vec<solana_instruction::AccountMeta>,
 }
 
@@ -134,6 +136,12 @@ impl UpdateVaultBuilder {
         self
     }
 
+    #[inline(always)]
+    pub fn fee_recipient(&mut self, fee_recipient: solana_pubkey::Pubkey) -> &mut Self {
+        self.fee_recipient = Some(fee_recipient);
+        self
+    }
+
     /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(&mut self, account: solana_instruction::AccountMeta) -> &mut Self {
@@ -159,7 +167,8 @@ impl UpdateVaultBuilder {
             vault: self.vault.expect("vault is not set"),
         };
         let args = UpdateVaultInstructionArgs {
-            paused: self.paused.clone().expect("paused is not set"),
+            paused: self.paused,
+            fee_recipient: self.fee_recipient,
         };
 
         accounts.instruction_with_remaining_accounts(args, &self.__remaining_accounts)
@@ -293,6 +302,7 @@ impl<'a, 'b> UpdateVaultCpiBuilder<'a, 'b> {
             share_mint: None,
             vault: None,
             paused: None,
+            fee_recipient: None,
             __remaining_accounts: Vec::new(),
         });
         Self { instruction }
@@ -322,6 +332,12 @@ impl<'a, 'b> UpdateVaultCpiBuilder<'a, 'b> {
     #[inline(always)]
     pub fn paused(&mut self, paused: bool) -> &mut Self {
         self.instruction.paused = Some(paused);
+        self
+    }
+
+    #[inline(always)]
+    pub fn fee_recipient(&mut self, fee_recipient: solana_pubkey::Pubkey) -> &mut Self {
+        self.instruction.fee_recipient = Some(fee_recipient);
         self
     }
 
@@ -364,7 +380,8 @@ impl<'a, 'b> UpdateVaultCpiBuilder<'a, 'b> {
     #[allow(clippy::vec_init_then_push)]
     pub fn invoke_signed(&self, signers_seeds: &[&[&[u8]]]) -> solana_program_error::ProgramResult {
         let args = UpdateVaultInstructionArgs {
-            paused: self.instruction.paused.clone().expect("paused is not set"),
+            paused: self.instruction.paused,
+            fee_recipient: self.instruction.fee_recipient,
         };
         let instruction = UpdateVaultCpi {
             __program: self.instruction.__program,
@@ -390,6 +407,7 @@ struct UpdateVaultCpiBuilderInstruction<'a, 'b> {
     share_mint: Option<&'b solana_account_info::AccountInfo<'a>>,
     vault: Option<&'b solana_account_info::AccountInfo<'a>>,
     paused: Option<bool>,
+    fee_recipient: Option<solana_pubkey::Pubkey>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(&'b solana_account_info::AccountInfo<'a>, bool, bool)>,
 }

--- a/integration-tests/src/async_vault/update_async_vault.rs
+++ b/integration-tests/src/async_vault/update_async_vault.rs
@@ -8,9 +8,10 @@ use test_case::test_case;
 
 use crate::helper_functions::{assert_error_code, set_up_async_vault};
 
-#[test_case(true; "pause vault")]
-#[test_case(false ; "unpause vault")]
-fn test_update_async_vault(paused: bool) {
+#[test_case(Some(true), false; "pause vault")]
+#[test_case(Some(false), false; "unpause vault")]
+#[test_case(None, true; "update fee_recipient only")]
+fn test_update_async_vault(paused: Option<bool>, update_fee_recipient: bool) {
     let mut svm = LiteSVM::new();
 
     let program_bytes = include_bytes!("../../../target/deploy/async_vault.so");
@@ -34,11 +35,21 @@ fn test_update_async_vault(paused: bool) {
     let vault_account = svm.get_account(&vault_pubkey).unwrap();
     let vault_before = Vault::from_bytes(vault_account.data()).unwrap();
 
-    UpdateVaultAsyncBuilder::new()
+    let new_fee_recipient = Keypair::new();
+
+    let mut builder = UpdateVaultAsyncBuilder::new();
+    builder
         .authority(authority.pubkey())
         .share_mint(share_mint.pubkey())
-        .paused(paused)
-        .vault(vault_pubkey)
+        .vault(vault_pubkey);
+    if let Some(p) = paused {
+        builder.paused(p);
+    }
+    if update_fee_recipient {
+        builder.fee_recipient(new_fee_recipient.pubkey());
+    }
+
+    builder
         .instruction()
         .send_transaction(&mut svm, &authority.pubkey(), &[&authority])
         .expect("update vault should succeed");
@@ -46,7 +57,17 @@ fn test_update_async_vault(paused: bool) {
     let vault_account = svm.get_account(&vault_pubkey).unwrap();
     let vault_after = Vault::from_bytes(vault_account.data()).unwrap();
 
-    assert_eq!(vault_after.paused, paused);
+    if let Some(p) = paused {
+        assert_eq!(vault_after.paused, p);
+    } else {
+        assert_eq!(vault_after.paused, vault_before.paused);
+    }
+
+    if update_fee_recipient {
+        assert_eq!(vault_after.fee_recipient, new_fee_recipient.pubkey());
+    } else {
+        assert_eq!(vault_after.fee_recipient, vault_before.fee_recipient);
+    }
 
     assert_eq!(vault_after.authority, vault_before.authority);
     assert_eq!(vault_after.asset_mint, vault_before.asset_mint);

--- a/programs/async_vault/src/instructions/update_vault.rs
+++ b/programs/async_vault/src/instructions/update_vault.rs
@@ -8,7 +8,8 @@ use crate::{
 
 #[derive(AnchorDeserialize, AnchorSerialize)]
 pub struct UpdateVaultArgs {
-    paused: Option<bool>,
+    pub paused: Option<bool>,
+    pub fee_recipient: Option<Pubkey>,
 }
 
 #[derive(Accounts)]
@@ -26,10 +27,16 @@ pub struct UpdateVault<'info> {
     pub vault: Account<'info, Vault>,
 }
 
-pub fn handler(ctx: Context<UpdateVault>, paused: bool) -> Result<()> {
+pub fn handler(ctx: Context<UpdateVault>, args: UpdateVaultArgs) -> Result<()> {
     let vault = &mut ctx.accounts.vault;
 
-    vault.paused = paused;
+    if let Some(paused) = args.paused {
+        vault.paused = paused;
+    }
+
+    if let Some(fee_recipient) = args.fee_recipient {
+        vault.fee_recipient = fee_recipient;
+    }
 
     Ok(())
 }

--- a/programs/async_vault/src/lib.rs
+++ b/programs/async_vault/src/lib.rs
@@ -56,8 +56,8 @@ pub mod async_vault {
     }
     /// Updates the async vault configuration. Can modify paused status,
     /// async inflows, and async outflows. Requires authority signature.
-    pub fn update_vault(ctx: Context<UpdateVault>, paused: bool) -> Result<()> {
-        instructions::update_vault::handler(ctx, paused)
+    pub fn update_vault(ctx: Context<UpdateVault>, args: UpdateVaultArgs) -> Result<()> {
+        instructions::update_vault::handler(ctx, args)
     }
 
     /// Updates the vault nav and increases nav version by 1

--- a/programs/async_vault/src/lib.rs
+++ b/programs/async_vault/src/lib.rs
@@ -54,8 +54,8 @@ pub mod async_vault {
     pub fn accept_authority_invitation(ctx: Context<AcceptAuthorityInvitation>) -> Result<()> {
         instructions::accept_authority_invitation::handler(ctx)
     }
-    /// Updates the async vault configuration. Can modify paused status,
-    /// async inflows, and async outflows. Requires authority signature.
+    /// Updates the async vault configuration. Can modify paused status
+    /// and the fee_recipient. Requires authority signature.
     pub fn update_vault(ctx: Context<UpdateVault>, args: UpdateVaultArgs) -> Result<()> {
         instructions::update_vault::handler(ctx, args)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault updates now support independent modification of paused state and fee recipient, enabling flexible configuration adjustments in a single transaction.
* **Tests**
  * Integration tests expanded to cover pausing, unpausing, fee-recipient-only updates, and combined scenarios; assertions now verify conditional behavior when fields are omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->