### PR TITLE
Add negative test for set_operator

### DIFF
--- a/integration-tests/src/async_vault/set_operator.rs
+++ b/integration-tests/src/async_vault/set_operator.rs
@@ -7,7 +7,10 @@ use async_vault_client::{
 use litesvm::LiteSVM;
 use solana_sdk::{account::ReadableAccount, signature::Keypair, signer::Signer};
 
-use crate::async_helper_functions::{assert_error_code, set_up_async_vault};
+use crate::{
+    async_helper_functions::{assert_error_code, set_up_async_vault},
+    async_vault::constants::UNAUTHORIZED_SIGNER,
+};
 
 #[test]
 fn test_set_operator_succeeds() {
@@ -110,6 +113,7 @@ fn test_set_operator_unauthorized_user_fails() {
     ) = set_up_async_vault(&mut svm, token::ID, None, token::ID, 1_000_000_000);
 
     InitializeAsyncVaultBuilder::new()
+        .share_mint(share_mint.pubkey())
         .authority(authority.pubkey())
         .vault(vault_pubkey)
         .instruction()
@@ -158,5 +162,5 @@ fn test_set_operator_unauthorized_user_fails() {
         .send_transaction(&mut svm, &attacker.pubkey(), &[&attacker, &operator])
         .unwrap_err();
 
-    assert_error_code(&err, 6001, "UnauthorizedSigner");
+    assert_error_code(&err, UNAUTHORIZED_SIGNER, "UnauthorizedSigner");
 }

--- a/integration-tests/src/async_vault/set_operator.rs
+++ b/integration-tests/src/async_vault/set_operator.rs
@@ -7,7 +7,7 @@ use async_vault_client::{
 use litesvm::LiteSVM;
 use solana_sdk::{account::ReadableAccount, signature::Keypair, signer::Signer};
 
-use crate::async_helper_functions::set_up_async_vault;
+use crate::async_helper_functions::{assert_error_code, set_up_async_vault};
 
 #[test]
 fn test_set_operator_succeeds() {
@@ -84,4 +84,79 @@ fn test_set_operator_succeeds() {
         .expect("Request account should exist");
     let request_data = Request::from_bytes(request_account.data()).unwrap();
     assert_eq!(request_data.operator, Some(operator.pubkey()));
+}
+
+#[test]
+fn test_set_operator_unauthorized_user_fails() {
+    let mut svm = LiteSVM::new();
+
+    let program_bytes = include_bytes!("../../../target/deploy/async_vault.so");
+    svm.add_program(program_id(), program_bytes).unwrap();
+
+    let (
+        authority,
+        _payer,
+        _mint_authority,
+        asset_mint,
+        share_mint,
+        user,
+        operator,
+        _fee_recipient,
+        _reserve_pubkey,
+        vault_pubkey,
+        pending_vault_pubkey,
+        _pending_shares_vault_pubkey,
+        _fee_recipient_ata,
+    ) = set_up_async_vault(&mut svm, token::ID, None, token::ID, 1_000_000_000);
+
+    InitializeAsyncVaultBuilder::new()
+        .authority(authority.pubkey())
+        .vault(vault_pubkey)
+        .instruction()
+        .send_transaction(&mut svm, &authority.pubkey(), &[&authority])
+        .expect("initialize vault should succeed");
+    UpdateVaultNavBuilder::new()
+        .authority(authority.pubkey())
+        .vault(vault_pubkey)
+        .updated_nav(100)
+        .instruction()
+        .send_transaction(&mut svm, &authority.pubkey(), &[&authority])
+        .expect("update nav should succeed");
+
+    let user_token_account = get_associated_token_address_with_program_id(
+        &user.pubkey(),
+        &asset_mint.pubkey(),
+        &token::ID,
+    );
+
+    let request_keypair = Keypair::new();
+    CreateDepositRequestBuilder::new()
+        .user(user.pubkey())
+        .asset_mint(asset_mint.pubkey())
+        .share_mint(share_mint.pubkey())
+        .request(request_keypair.pubkey())
+        .vault(vault_pubkey)
+        .user_token_account(user_token_account)
+        .pending_vault(pending_vault_pubkey)
+        .asset_token_program(spl_token::ID)
+        .args(RequestArgs {
+            amount: 1_000_000,
+            operator: None,
+        })
+        .instruction()
+        .send_transaction(&mut svm, &user.pubkey(), &[&user, &request_keypair])
+        .expect("create deposit request should succeed");
+
+    let attacker = Keypair::new();
+    svm.airdrop(&attacker.pubkey(), 1_000_000_000).unwrap();
+
+    let err = SetOperatorBuilder::new()
+        .user(attacker.pubkey())
+        .operator(operator.pubkey())
+        .request(request_keypair.pubkey())
+        .instruction()
+        .send_transaction(&mut svm, &attacker.pubkey(), &[&attacker, &operator])
+        .unwrap_err();
+
+    assert_error_code(&err, 6001, "UnauthorizedSigner");
 }


### PR DESCRIPTION
## Summary

Adds negative coverage for `set_operator` as part of #57.

This test verifies that a signer who is not the request owner cannot set an operator, and that the call fails with `UnauthorizedSigner`.

## Test

```bash
cargo test -p integration-tests async_vault::set_operator:: -- --nocapture
```

<img width="758" height="137" alt="Screenshot 2026-05-31 at 4 03 51 PM" src="https://github.com/user-attachments/assets/cc6f3178-9dd6-44ef-ab59-a73a5faf6d32" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test to verify security validation for operator changes with unauthorized signers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->