### PR TITLE
Add reject_request negative tests

### DIFF
--- a/integration-tests/src/async_vault/constants.rs
+++ b/integration-tests/src/async_vault/constants.rs
@@ -1,1 +1,4 @@
-
+pub(crate) const UNAUTHORIZED_SIGNER: u32 = 6001;
+pub(crate) const REQUEST_INVALID_STATE: u32 = 6017;
+pub(crate) const MISSING_REQUIRED_ACCOUNT: u32 = 6020;
+pub(crate) const APPROVAL_REQUEST_MISMATCH: u32 = 6038;

--- a/integration-tests/src/async_vault/reject_request.rs
+++ b/integration-tests/src/async_vault/reject_request.rs
@@ -1,6 +1,6 @@
 use anchor_spl::{associated_token::get_associated_token_address_with_program_id, token};
 use async_vault_client::{
-    lite::SendTransaction, sdk::program_id, CreateDepositRequestBuilder,
+    lite::SendTransaction, sdk::program_id, ApproveRequestBuilder, CreateDepositRequestBuilder,
     CreateRedeemRequestBuilder, InitializeVaultBuilder as InitializeAsyncVaultBuilder,
     RejectRequestBuilder, RequestArgs, UpdateVaultNavBuilder, Vault,
 };
@@ -12,6 +12,14 @@ use crate::async_helper_functions::{
     approve_request_args, assert_error_code, get_token_account_amount, set_share_balance,
     set_up_async_vault,
 };
+
+#[derive(Clone, Copy)]
+enum RejectDepositFailure {
+    WrongAuthority,
+    WrongUser,
+    ClaimableRequest,
+    MissingRequiredAccounts,
+}
 
 #[test_case(1_000_000 ; "reject deposit request refunds user")]
 #[test_case(1 ; "reject minimum deposit succeeds")]
@@ -229,6 +237,236 @@ fn test_reject_redeem_request(share_amount: u64) {
 
     let vault_after = Vault::from_bytes(svm.get_account(&vault_pubkey).unwrap().data()).unwrap();
     assert_eq!(vault_after.pending_async_requests, pending_before - 1);
+}
+
+#[test_case(RejectDepositFailure::WrongAuthority, 6001, "UnauthorizedSigner" ; "wrong_authority")]
+#[test_case(RejectDepositFailure::WrongUser, 6001, "UnauthorizedSigner" ; "wrong_user")]
+#[test_case(RejectDepositFailure::ClaimableRequest, 6017, "RequestInvalidState" ; "claimable_request")]
+#[test_case(RejectDepositFailure::MissingRequiredAccounts, 6020, "MissingRequiredAccount" ; "missing_required_accounts")]
+fn test_reject_deposit_request_fails(
+    failure: RejectDepositFailure,
+    expected_error_code: u32,
+    expected_error_name: &str,
+) {
+    let mut svm = LiteSVM::new();
+    let program_bytes = include_bytes!("../../../target/deploy/async_vault.so");
+    svm.add_program(program_id(), program_bytes).unwrap();
+
+    let user_amount = 1_000_000_000;
+    let (
+        authority,
+        _payer,
+        _mint_authority,
+        asset_mint,
+        share_mint,
+        user,
+        _operator,
+        _fee_recipient,
+        reserve_pubkey,
+        vault_pubkey,
+        pending_vault_pubkey,
+        _fee_recipient_ata,
+        _user_share_account,
+    ) = set_up_async_vault(&mut svm, token::ID, Some(0), token::ID, user_amount);
+
+    InitializeAsyncVaultBuilder::new()
+        .share_mint(share_mint.pubkey())
+        .authority(authority.pubkey())
+        .vault(vault_pubkey)
+        .instruction()
+        .send_transaction(&mut svm, &authority.pubkey(), &[&authority])
+        .expect("initialize vault should succeed");
+    UpdateVaultNavBuilder::new()
+        .authority(authority.pubkey())
+        .vault(vault_pubkey)
+        .updated_nav(100)
+        .instruction()
+        .send_transaction(&mut svm, &authority.pubkey(), &[&authority])
+        .expect("update nav should succeed");
+
+    let user_token_account = get_associated_token_address_with_program_id(
+        &user.pubkey(),
+        &asset_mint.pubkey(),
+        &token::ID,
+    );
+
+    let request_keypair = Keypair::new();
+    CreateDepositRequestBuilder::new()
+        .user(user.pubkey())
+        .asset_mint(asset_mint.pubkey())
+        .share_mint(share_mint.pubkey())
+        .request(request_keypair.pubkey())
+        .vault(vault_pubkey)
+        .user_token_account(user_token_account)
+        .pending_vault(pending_vault_pubkey)
+        .asset_token_program(spl_token::ID)
+        .args(RequestArgs {
+            amount: 1_000_000,
+            operator: None,
+        })
+        .instruction()
+        .send_transaction(&mut svm, &user.pubkey(), &[&user, &request_keypair])
+        .expect("deposit request should succeed");
+
+    if matches!(failure, RejectDepositFailure::ClaimableRequest) {
+        let (owner, request_type, amount, created_at, nav_update_version) =
+            approve_request_args(&svm, &request_keypair.pubkey());
+
+        ApproveRequestBuilder::new()
+            .authority(authority.pubkey())
+            .vault(vault_pubkey)
+            .request(request_keypair.pubkey())
+            .owner(owner)
+            .request_type(request_type)
+            .amount(amount)
+            .created_at(created_at)
+            .nav_update_version(nav_update_version)
+            .asset_mint(asset_mint.pubkey())
+            .share_mint(share_mint.pubkey())
+            .vault_token_account(reserve_pubkey)
+            .pending_vault(pending_vault_pubkey)
+            .asset_token_program(token::ID)
+            .instruction()
+            .send_transaction(&mut svm, &authority.pubkey(), &[&authority])
+            .expect("approve request should succeed");
+    }
+
+    let attacker = if matches!(
+        failure,
+        RejectDepositFailure::WrongAuthority | RejectDepositFailure::WrongUser
+    ) {
+        let attacker = Keypair::new();
+        svm.airdrop(&attacker.pubkey(), 1_000_000_000).unwrap();
+        Some(attacker)
+    } else {
+        None
+    };
+
+    let (reject_authority, signer) = if matches!(failure, RejectDepositFailure::WrongAuthority) {
+        let attacker = attacker.as_ref().unwrap();
+        (attacker.pubkey(), attacker)
+    } else {
+        (authority.pubkey(), &authority)
+    };
+    let reject_user = if matches!(failure, RejectDepositFailure::WrongUser) {
+        attacker.as_ref().unwrap().pubkey()
+    } else {
+        user.pubkey()
+    };
+    let include_required_accounts =
+        !matches!(failure, RejectDepositFailure::MissingRequiredAccounts);
+    let (owner, request_type, amount, created_at, nav_update_version) =
+        approve_request_args(&svm, &request_keypair.pubkey());
+
+    let err = RejectRequestBuilder::new()
+        .authority(reject_authority)
+        .user(reject_user)
+        .asset_mint(asset_mint.pubkey())
+        .share_mint(share_mint.pubkey())
+        .request(request_keypair.pubkey())
+        .owner(owner)
+        .request_type(request_type)
+        .amount(amount)
+        .created_at(created_at)
+        .nav_update_version(nav_update_version)
+        .vault(vault_pubkey)
+        .user_token_account(include_required_accounts.then_some(user_token_account))
+        .asset_pending_vault(include_required_accounts.then_some(pending_vault_pubkey))
+        .asset_token_program(include_required_accounts.then_some(token::ID))
+        .user_share_account(None)
+        .share_token_program(None)
+        .instruction()
+        .send_transaction(&mut svm, &signer.pubkey(), &[signer])
+        .unwrap_err();
+
+    assert_error_code(&err, expected_error_code, expected_error_name);
+}
+
+#[test]
+fn test_reject_redeem_request_missing_required_accounts_fails() {
+    let mut svm = LiteSVM::new();
+    let program_bytes = include_bytes!("../../../target/deploy/async_vault.so");
+    svm.add_program(program_id(), program_bytes).unwrap();
+
+    let (
+        authority,
+        _payer,
+        _mint_authority,
+        asset_mint,
+        share_mint,
+        user,
+        _operator,
+        _fee_recipient,
+        _reserve_pubkey,
+        vault_pubkey,
+        _pending_vault_pubkey,
+        _fee_recipient_ata,
+        user_share_account,
+    ) = set_up_async_vault(&mut svm, token::ID, None, token::ID, 0);
+
+    InitializeAsyncVaultBuilder::new()
+        .share_mint(share_mint.pubkey())
+        .authority(authority.pubkey())
+        .vault(vault_pubkey)
+        .instruction()
+        .send_transaction(&mut svm, &authority.pubkey(), &[&authority])
+        .expect("initialize vault should succeed");
+    UpdateVaultNavBuilder::new()
+        .authority(authority.pubkey())
+        .vault(vault_pubkey)
+        .updated_nav(100)
+        .instruction()
+        .send_transaction(&mut svm, &authority.pubkey(), &[&authority])
+        .expect("update nav should succeed");
+
+    set_share_balance(
+        &mut svm,
+        &user_share_account,
+        &share_mint.pubkey(),
+        1_000_000,
+    );
+
+    let request_keypair = Keypair::new();
+    CreateRedeemRequestBuilder::new()
+        .user(user.pubkey())
+        .asset_mint(asset_mint.pubkey())
+        .share_mint(share_mint.pubkey())
+        .request(request_keypair.pubkey())
+        .vault(vault_pubkey)
+        .user_share_account(user_share_account)
+        .share_token_program(spl_token::ID)
+        .args(RequestArgs {
+            amount: 1_000_000,
+            operator: None,
+        })
+        .instruction()
+        .send_transaction(&mut svm, &user.pubkey(), &[&user, &request_keypair])
+        .expect("redeem request should succeed");
+
+    let (owner, request_type, amount, created_at, nav_update_version) =
+        approve_request_args(&svm, &request_keypair.pubkey());
+    let err = RejectRequestBuilder::new()
+        .authority(authority.pubkey())
+        .user(user.pubkey())
+        .asset_mint(asset_mint.pubkey())
+        .share_mint(share_mint.pubkey())
+        .request(request_keypair.pubkey())
+        .owner(owner)
+        .request_type(request_type)
+        .amount(amount)
+        .created_at(created_at)
+        .nav_update_version(nav_update_version)
+        .vault(vault_pubkey)
+        .user_token_account(None)
+        .asset_pending_vault(None)
+        .asset_token_program(None)
+        .user_share_account(None)
+        .share_token_program(None)
+        .instruction()
+        .send_transaction(&mut svm, &authority.pubkey(), &[&authority])
+        .unwrap_err();
+
+    assert_error_code(&err, 6020, "MissingRequiredAccount");
 }
 
 #[test]

--- a/integration-tests/src/async_vault/reject_request.rs
+++ b/integration-tests/src/async_vault/reject_request.rs
@@ -12,6 +12,9 @@ use crate::async_helper_functions::{
     approve_request_args, assert_error_code, get_token_account_amount, set_share_balance,
     set_up_async_vault,
 };
+use crate::async_vault::constants::{
+    APPROVAL_REQUEST_MISMATCH, MISSING_REQUIRED_ACCOUNT, REQUEST_INVALID_STATE, UNAUTHORIZED_SIGNER,
+};
 
 #[derive(Clone, Copy)]
 enum RejectDepositFailure {
@@ -239,10 +242,10 @@ fn test_reject_redeem_request(share_amount: u64) {
     assert_eq!(vault_after.pending_async_requests, pending_before - 1);
 }
 
-#[test_case(RejectDepositFailure::WrongAuthority, 6001, "UnauthorizedSigner" ; "wrong_authority")]
-#[test_case(RejectDepositFailure::WrongUser, 6001, "UnauthorizedSigner" ; "wrong_user")]
-#[test_case(RejectDepositFailure::ClaimableRequest, 6017, "RequestInvalidState" ; "claimable_request")]
-#[test_case(RejectDepositFailure::MissingRequiredAccounts, 6020, "MissingRequiredAccount" ; "missing_required_accounts")]
+#[test_case(RejectDepositFailure::WrongAuthority, UNAUTHORIZED_SIGNER, "UnauthorizedSigner" ; "wrong_authority")]
+#[test_case(RejectDepositFailure::WrongUser, UNAUTHORIZED_SIGNER, "UnauthorizedSigner" ; "wrong_user")]
+#[test_case(RejectDepositFailure::ClaimableRequest, REQUEST_INVALID_STATE, "RequestInvalidState" ; "claimable_request")]
+#[test_case(RejectDepositFailure::MissingRequiredAccounts, MISSING_REQUIRED_ACCOUNT, "MissingRequiredAccount" ; "missing_required_accounts")]
 fn test_reject_deposit_request_fails(
     failure: RejectDepositFailure,
     expected_error_code: u32,
@@ -466,12 +469,11 @@ fn test_reject_redeem_request_missing_required_accounts_fails() {
         .send_transaction(&mut svm, &authority.pubkey(), &[&authority])
         .unwrap_err();
 
-    assert_error_code(&err, 6020, "MissingRequiredAccount");
+    assert_error_code(&err, MISSING_REQUIRED_ACCOUNT, "MissingRequiredAccount");
 }
 
 #[test]
 fn test_reject_rejects_mismatched_request_args() {
-    const APPROVAL_REQUEST_MISMATCH: u32 = 6038;
     let user_amount = 1_000_000_000;
     let deposit_amount = 1_000_000;
 

--- a/integration-tests/src/async_vault/reject_request.rs
+++ b/integration-tests/src/async_vault/reject_request.rs
@@ -8,12 +8,15 @@ use litesvm::LiteSVM;
 use solana_sdk::{account::ReadableAccount, signature::Keypair, signer::Signer};
 use test_case::test_case;
 
-use crate::async_helper_functions::{
-    approve_request_args, assert_error_code, get_token_account_amount, set_share_balance,
-    set_up_async_vault,
-};
-use crate::async_vault::constants::{
-    APPROVAL_REQUEST_MISMATCH, MISSING_REQUIRED_ACCOUNT, REQUEST_INVALID_STATE, UNAUTHORIZED_SIGNER,
+use crate::{
+    async_helper_functions::{
+        approve_request_args, assert_error_code, get_token_account_amount, set_share_balance,
+        set_up_async_vault,
+    },
+    async_vault::constants::{
+        APPROVAL_REQUEST_MISMATCH, MISSING_REQUIRED_ACCOUNT, REQUEST_INVALID_STATE,
+        UNAUTHORIZED_SIGNER,
+    },
 };
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
## Summary

Adds negative test coverage for the core `reject_request` instruction as part of #57.

The test suite now verifies the following failure scenarios:

* Incorrect vault authority
* Incorrect request user
* Attempting to reject a request that is already claimable
* Missing required accounts for deposit refunds
* Missing required accounts for redeem mint-back operations

## Test

```bash
cargo test -p integration-tests async_vault::reject_request:: -- --nocapture
```


<img width="913" height="252" alt="Screenshot 2026-05-31 at 4 29 10 PM" src="https://github.com/user-attachments/assets/65b18815-2469-4523-ada2-2d55f49e995a" />
