### PR TITLE
Add update nav negative tests

### DIFF
--- a/integration-tests/src/async_vault/constants.rs
+++ b/integration-tests/src/async_vault/constants.rs
@@ -1,4 +1,5 @@
 pub(crate) const UNAUTHORIZED_SIGNER: u32 = 6001;
+pub(crate) const ARITHMETIC_ERROR: u32 = 6009;
 pub(crate) const REQUEST_INVALID_STATE: u32 = 6017;
 pub(crate) const MISSING_REQUIRED_ACCOUNT: u32 = 6020;
 pub(crate) const APPROVAL_REQUEST_MISMATCH: u32 = 6038;

--- a/integration-tests/src/async_vault/update_vault_nav.rs
+++ b/integration-tests/src/async_vault/update_vault_nav.rs
@@ -1,10 +1,11 @@
 use anchor_spl::token;
 use async_vault_client::{lite::SendTransaction, sdk::program_id, UpdateVaultNavBuilder, Vault};
+use borsh::BorshSerialize;
 use litesvm::LiteSVM;
-use solana_sdk::{account::ReadableAccount, signer::Signer};
+use solana_sdk::{account::ReadableAccount, signature::Keypair, signer::Signer};
 use test_case::test_case;
 
-use crate::async_helper_functions::set_up_async_vault;
+use crate::async_helper_functions::{assert_error_code, set_up_async_vault};
 
 #[test_case(200 ; "update nav succeeds")]
 #[test_case(0 ; "update nav to zero succeeds")]
@@ -53,4 +54,79 @@ fn test_update_vault_nav(updated_nav: u128) {
 
     assert_eq!(vault_config.nav, updated_nav);
     assert_eq!(vault_config.nav_version, nav_version_before + 1);
+}
+
+#[test]
+fn test_update_vault_nav_unauthorized_signer_fails() {
+    let mut svm = LiteSVM::new();
+    let program_bytes = include_bytes!("../../../target/deploy/async_vault.so");
+    svm.add_program(program_id(), program_bytes).unwrap();
+
+    let (
+        _authority,
+        _payer,
+        _mint_authority,
+        _asset_mint,
+        _share_mint,
+        _user,
+        _operator,
+        _fee_recipient,
+        _reserve_pubkey,
+        vault_pubkey,
+        _pending_vault_pubkey,
+        _fee_recipient_ata,
+        _user_share_account,
+    ) = set_up_async_vault(&mut svm, token::ID, None, token::ID, 1_000_000_000);
+
+    let unauthorized = Keypair::new();
+    svm.airdrop(&unauthorized.pubkey(), 1_000_000_000).unwrap();
+
+    let result = UpdateVaultNavBuilder::new()
+        .authority(unauthorized.pubkey())
+        .vault(vault_pubkey)
+        .updated_nav(200)
+        .instruction()
+        .send_transaction(&mut svm, &unauthorized.pubkey(), &[&unauthorized]);
+
+    assert_error_code(&result.unwrap_err(), 6001, "UnauthorizedSigner");
+}
+
+#[test]
+fn test_update_vault_nav_version_overflow_fails() {
+    let mut svm = LiteSVM::new();
+    let program_bytes = include_bytes!("../../../target/deploy/async_vault.so");
+    svm.add_program(program_id(), program_bytes).unwrap();
+
+    let (
+        authority,
+        _payer,
+        _mint_authority,
+        _asset_mint,
+        _share_mint,
+        _user,
+        _operator,
+        _fee_recipient,
+        _reserve_pubkey,
+        vault_pubkey,
+        _pending_vault_pubkey,
+        _fee_recipient_ata,
+        _user_share_account,
+    ) = set_up_async_vault(&mut svm, token::ID, None, token::ID, 1_000_000_000);
+
+    let mut account = svm.get_account(&vault_pubkey).expect("vault should exist");
+    let mut vault = Vault::from_bytes(account.data()).unwrap();
+    vault.nav_version = u64::MAX;
+    let mut buf = Vec::new();
+    vault.serialize(&mut buf).unwrap();
+    account.data = buf;
+    svm.set_account(vault_pubkey, account).unwrap();
+
+    let result = UpdateVaultNavBuilder::new()
+        .authority(authority.pubkey())
+        .vault(vault_pubkey)
+        .updated_nav(200)
+        .instruction()
+        .send_transaction(&mut svm, &authority.pubkey(), &[&authority]);
+
+    assert_error_code(&result.unwrap_err(), 6002, "ArithmeticError");
 }

--- a/integration-tests/src/async_vault/update_vault_nav.rs
+++ b/integration-tests/src/async_vault/update_vault_nav.rs
@@ -5,7 +5,10 @@ use litesvm::LiteSVM;
 use solana_sdk::{account::ReadableAccount, signature::Keypair, signer::Signer};
 use test_case::test_case;
 
-use crate::async_helper_functions::{assert_error_code, set_up_async_vault};
+use crate::{
+    async_helper_functions::{assert_error_code, set_up_async_vault},
+    async_vault::constants::{ARITHMETIC_ERROR, UNAUTHORIZED_SIGNER},
+};
 
 #[test_case(200 ; "update nav succeeds")]
 #[test_case(0 ; "update nav to zero succeeds")]
@@ -88,7 +91,11 @@ fn test_update_vault_nav_unauthorized_signer_fails() {
         .instruction()
         .send_transaction(&mut svm, &unauthorized.pubkey(), &[&unauthorized]);
 
-    assert_error_code(&result.unwrap_err(), 6001, "UnauthorizedSigner");
+    assert_error_code(
+        &result.unwrap_err(),
+        UNAUTHORIZED_SIGNER,
+        "UnauthorizedSigner",
+    );
 }
 
 #[test]
@@ -118,6 +125,8 @@ fn test_update_vault_nav_version_overflow_fails() {
     vault.nav_version = u64::MAX;
     let mut buf = Vec::new();
     vault.serialize(&mut buf).unwrap();
+    let tlv_bytes = account.data()[buf.len()..].to_vec();
+    buf.extend_from_slice(&tlv_bytes);
     account.data = buf;
     svm.set_account(vault_pubkey, account).unwrap();
 
@@ -128,5 +137,5 @@ fn test_update_vault_nav_version_overflow_fails() {
         .instruction()
         .send_transaction(&mut svm, &authority.pubkey(), &[&authority]);
 
-    assert_error_code(&result.unwrap_err(), 6002, "ArithmeticError");
+    assert_error_code(&result.unwrap_err(), ARITHMETIC_ERROR, "ArithmeticError");
 }


### PR DESCRIPTION
## Summary

Adds negative test coverage for the core `update_vault_nav` instruction as part of #57.

The test suite now verifies the following failure scenarios:

* Incorrect vault authority
* NAV version overflow

## Test

```bash
cargo test -p integration-tests async_vault::update_vault_nav:: -- --nocapture
```

<img width="787" height="186" alt="Screenshot 2026-05-31 at 4 47 13 PM" src="https://github.com/user-attachments/assets/2bd2935b-ed7f-4d28-ba8a-75e5c0e72158" />
