### PR TITLE
Add create request negative tests

### DIFF
--- a/integration-tests/src/async_helper_functions.rs
+++ b/integration-tests/src/async_helper_functions.rs
@@ -413,3 +413,15 @@ pub fn set_vault_total_asset_balance(svm: &mut LiteSVM, vault: Pubkey, amount: u
     account.data = buf;
     svm.set_account(vault, account).unwrap();
 }
+
+pub fn set_vault_pending_async_requests(svm: &mut LiteSVM, vault: Pubkey, count: u16) {
+    let mut account = svm.get_account(&vault).unwrap();
+    let mut vault_state = AsyncVault::from_bytes(account.data()).unwrap();
+    vault_state.pending_async_requests = count;
+    let mut buf = Vec::new();
+    vault_state.serialize(&mut buf).unwrap();
+    let tlv_bytes = account.data()[buf.len()..].to_vec();
+    buf.extend_from_slice(&tlv_bytes);
+    account.data = buf;
+    svm.set_account(vault, account).unwrap();
+}

--- a/integration-tests/src/async_vault/cancel_request.rs
+++ b/integration-tests/src/async_vault/cancel_request.rs
@@ -13,7 +13,7 @@ use test_case::test_case;
 use crate::{
     async_helper_functions::{
         assert_error_code, create_ata, get_token_account_amount, set_share_balance,
-        set_up_async_vault,
+        set_up_async_vault, set_vault_pending_async_requests,
     },
     async_vault::constants::{
         ARITHMETIC_ERROR, MISSING_REQUIRED_ACCOUNT, PAUSED_VAULT, REQUEST_IS_NOT_PENDING,
@@ -38,18 +38,6 @@ fn set_request_state(svm: &mut LiteSVM, request_pubkey: Pubkey, state: RequestSt
     buf.extend_from_slice(&tlv_bytes);
     account.data = buf;
     svm.set_account(request_pubkey, account).unwrap();
-}
-
-fn set_vault_pending_async_requests(svm: &mut LiteSVM, vault_pubkey: Pubkey, count: u16) {
-    let mut account = svm.get_account(&vault_pubkey).unwrap();
-    let mut vault = Vault::from_bytes(account.data()).unwrap();
-    vault.pending_async_requests = count;
-    let mut buf = Vec::new();
-    vault.serialize(&mut buf).unwrap();
-    let tlv_bytes = account.data()[buf.len()..].to_vec();
-    buf.extend_from_slice(&tlv_bytes);
-    account.data = buf;
-    svm.set_account(vault_pubkey, account).unwrap();
 }
 
 #[test_case(1_000_000 ; "cancel deposit request refunds user")]

--- a/integration-tests/src/async_vault/constants.rs
+++ b/integration-tests/src/async_vault/constants.rs
@@ -1,7 +1,11 @@
 pub(crate) const UNAUTHORIZED_SIGNER: u32 = 6001;
+pub(crate) const UNINITIALIZED_VAULT: u32 = 6002;
 pub(crate) const PAUSED_VAULT: u32 = 6003;
 pub(crate) const ARITHMETIC_ERROR: u32 = 6009;
 pub(crate) const REQUEST_INVALID_STATE: u32 = 6017;
 pub(crate) const REQUEST_IS_NOT_PENDING: u32 = 6018;
 pub(crate) const MISSING_REQUIRED_ACCOUNT: u32 = 6020;
+pub(crate) const INVALID_ASSET_MINT_EXTENSIONS: u32 = 6021;
+pub(crate) const INSUFFICIENT_REDEEM_AMOUNT: u32 = 6037;
 pub(crate) const APPROVAL_REQUEST_MISMATCH: u32 = 6038;
+pub(crate) const INSUFFICIENT_DEPOSIT_AMOUNT: u32 = 6039;

--- a/integration-tests/src/async_vault/create_deposit_request.rs
+++ b/integration-tests/src/async_vault/create_deposit_request.rs
@@ -4,7 +4,7 @@ use anchor_spl::{
 use async_vault_client::{
     lite::SendTransaction, sdk::program_id, CreateDepositRequestBuilder,
     InitializeVaultBuilder as InitializeAsyncVaultBuilder, Request, RequestArgs, RequestState,
-    RequestType, UpdateVaultNavBuilder,
+    RequestType, UpdateVaultBuilder as UpdateVaultAsyncBuilder, UpdateVaultNavBuilder,
 };
 use litesvm::LiteSVM;
 use solana_sdk::{
@@ -13,9 +13,23 @@ use solana_sdk::{
 };
 use test_case::test_case;
 
-use crate::async_helper_functions::{
-    assert_error_code, get_token_account_amount, set_up_async_vault,
+use crate::{
+    async_helper_functions::{
+        assert_error_code, get_token_account_amount, set_up_async_vault,
+        set_vault_pending_async_requests,
+    },
+    async_vault::constants::{
+        ARITHMETIC_ERROR, INSUFFICIENT_DEPOSIT_AMOUNT, INVALID_ASSET_MINT_EXTENSIONS, PAUSED_VAULT,
+        UNINITIALIZED_VAULT,
+    },
 };
+
+#[derive(Clone, Copy)]
+enum CreateDepositRequestFailure {
+    UninitializedVault,
+    PausedVault,
+    PendingRequestsOverflow,
+}
 
 #[test_case(1_000_000, false ; "deposit request succeeds")]
 #[test_case(1_000_000, true ; "deposit with operator succeeds")]
@@ -160,8 +174,95 @@ fn test_create_deposit_request(deposit_amount: u64, with_operator: bool) {
     );
 }
 
-#[test_case(Some(1), 1_000_000, 6021 ; "deposit_request_with_nonzero_transfer_fee_fails")]
-#[test_case(None, 0, 6039 ; "zero_amount_deposit_fails")]
+#[test_case(CreateDepositRequestFailure::UninitializedVault, UNINITIALIZED_VAULT, "UninitializedVault" ; "uninitialized vault")]
+#[test_case(CreateDepositRequestFailure::PausedVault, PAUSED_VAULT, "PausedVault" ; "paused vault")]
+#[test_case(CreateDepositRequestFailure::PendingRequestsOverflow, ARITHMETIC_ERROR, "ArithmeticError" ; "pending requests overflow")]
+fn test_create_deposit_request_negative(
+    failure: CreateDepositRequestFailure,
+    expected_error_code: u32,
+    expected_error_name: &str,
+) {
+    let mut svm = LiteSVM::new();
+    let program_bytes = include_bytes!("../../../target/deploy/async_vault.so");
+    svm.add_program(program_id(), program_bytes).unwrap();
+
+    let user_amount = 1_000_000_000;
+    let (
+        authority,
+        _payer,
+        _mint_authority,
+        asset_mint,
+        share_mint,
+        user,
+        _operator,
+        _fee_recipient,
+        _reserve_pubkey,
+        vault_pubkey,
+        pending_vault_pubkey,
+        _fee_recipient_ata,
+        _user_share_account,
+    ) = set_up_async_vault(&mut svm, token::ID, Some(0), token::ID, user_amount);
+
+    if !matches!(failure, CreateDepositRequestFailure::UninitializedVault) {
+        InitializeAsyncVaultBuilder::new()
+            .share_mint(share_mint.pubkey())
+            .authority(authority.pubkey())
+            .vault(vault_pubkey)
+            .instruction()
+            .send_transaction(&mut svm, &authority.pubkey(), &[&authority])
+            .expect("initialize vault should succeed");
+    }
+
+    if matches!(failure, CreateDepositRequestFailure::PausedVault) {
+        UpdateVaultAsyncBuilder::new()
+            .authority(authority.pubkey())
+            .share_mint(share_mint.pubkey())
+            .paused(true)
+            .vault(vault_pubkey)
+            .instruction()
+            .send_transaction(&mut svm, &authority.pubkey(), &[&authority])
+            .expect("pause vault should succeed");
+    }
+
+    if matches!(
+        failure,
+        CreateDepositRequestFailure::PendingRequestsOverflow
+    ) {
+        set_vault_pending_async_requests(&mut svm, vault_pubkey, u16::MAX);
+    }
+
+    let user_token_account = get_associated_token_address_with_program_id(
+        &user.pubkey(),
+        &asset_mint.pubkey(),
+        &token::ID,
+    );
+    let request_keypair = Keypair::new();
+
+    let result = CreateDepositRequestBuilder::new()
+        .user(user.pubkey())
+        .asset_mint(asset_mint.pubkey())
+        .share_mint(share_mint.pubkey())
+        .request(request_keypair.pubkey())
+        .vault(vault_pubkey)
+        .user_token_account(user_token_account)
+        .pending_vault(pending_vault_pubkey)
+        .asset_token_program(spl_token::ID)
+        .args(RequestArgs {
+            amount: 1_000_000,
+            operator: None,
+        })
+        .instruction()
+        .send_transaction(&mut svm, &user.pubkey(), &[&user, &request_keypair]);
+
+    assert_error_code(
+        &result.unwrap_err(),
+        expected_error_code,
+        expected_error_name,
+    );
+}
+
+#[test_case(Some(1), 1_000_000, INVALID_ASSET_MINT_EXTENSIONS ; "deposit_request_with_nonzero_transfer_fee_fails")]
+#[test_case(None, 0, INSUFFICIENT_DEPOSIT_AMOUNT ; "zero_amount_deposit_fails")]
 fn test_create_deposit_request_fails(
     asset_transfer_fee: Option<u16>,
     deposit_amount: u64,

--- a/integration-tests/src/async_vault/create_redeem_request.rs
+++ b/integration-tests/src/async_vault/create_redeem_request.rs
@@ -2,7 +2,7 @@ use anchor_spl::token;
 use async_vault_client::{
     lite::SendTransaction, sdk::program_id, CreateRedeemRequestBuilder,
     InitializeVaultBuilder as InitializeAsyncVaultBuilder, Request, RequestArgs, RequestState,
-    RequestType, UpdateVaultNavBuilder,
+    RequestType, UpdateVaultBuilder as UpdateVaultAsyncBuilder, UpdateVaultNavBuilder,
 };
 use litesvm::LiteSVM;
 use solana_sdk::{
@@ -10,13 +10,26 @@ use solana_sdk::{
 };
 use test_case::test_case;
 
-use crate::async_helper_functions::{
-    assert_error_code, get_token_account_amount, set_share_balance, set_up_async_vault,
+use crate::{
+    async_helper_functions::{
+        assert_error_code, get_token_account_amount, set_share_balance, set_up_async_vault,
+        set_vault_pending_async_requests,
+    },
+    async_vault::constants::{
+        ARITHMETIC_ERROR, INSUFFICIENT_REDEEM_AMOUNT, PAUSED_VAULT, UNINITIALIZED_VAULT,
+    },
 };
+
+#[derive(Clone, Copy)]
+enum CreateRedeemRequestFailure {
+    UninitializedVault,
+    PausedVault,
+    PendingRequestsOverflow,
+}
 
 #[test_case(1_000_000_000, false, None ; "redeem request succeeds")]
 #[test_case(1_000_000_000, true, None ; "redeem with operator succeeds")]
-#[test_case(0, false, Some((6011, "InsufficientRedeemAmount")) ; "zero amount fails")]
+#[test_case(0, false, Some((INSUFFICIENT_REDEEM_AMOUNT, "InsufficientRedeemAmount")) ; "zero amount fails")]
 fn test_create_redeem_request(
     share_amount: u64,
     with_operator: bool,
@@ -122,5 +135,88 @@ fn test_create_redeem_request(
     assert_eq!(
         get_token_account_amount(&svm.get_account(&user_share_account).unwrap()),
         0
+    );
+}
+
+#[test_case(CreateRedeemRequestFailure::UninitializedVault, UNINITIALIZED_VAULT, "UninitializedVault" ; "uninitialized vault")]
+#[test_case(CreateRedeemRequestFailure::PausedVault, PAUSED_VAULT, "PausedVault" ; "paused vault")]
+#[test_case(CreateRedeemRequestFailure::PendingRequestsOverflow, ARITHMETIC_ERROR, "ArithmeticError" ; "pending requests overflow")]
+fn test_create_redeem_request_negative(
+    failure: CreateRedeemRequestFailure,
+    expected_error_code: u32,
+    expected_error_name: &str,
+) {
+    let mut svm = LiteSVM::new();
+    let program_bytes = include_bytes!("../../../target/deploy/async_vault.so");
+    svm.add_program(program_id(), program_bytes).unwrap();
+
+    let (
+        authority,
+        _payer,
+        _mint_authority,
+        asset_mint,
+        share_mint,
+        user,
+        _operator,
+        _fee_recipient,
+        _reserve_pubkey,
+        vault_pubkey,
+        _pending_vault_pubkey,
+        _fee_recipient_ata,
+        user_share_account,
+    ) = set_up_async_vault(&mut svm, token::ID, None, token::ID, 0);
+
+    if !matches!(failure, CreateRedeemRequestFailure::UninitializedVault) {
+        InitializeAsyncVaultBuilder::new()
+            .share_mint(share_mint.pubkey())
+            .authority(authority.pubkey())
+            .vault(vault_pubkey)
+            .instruction()
+            .send_transaction(&mut svm, &authority.pubkey(), &[&authority])
+            .expect("initialize vault should succeed");
+    }
+
+    if matches!(failure, CreateRedeemRequestFailure::PausedVault) {
+        UpdateVaultAsyncBuilder::new()
+            .authority(authority.pubkey())
+            .share_mint(share_mint.pubkey())
+            .paused(true)
+            .vault(vault_pubkey)
+            .instruction()
+            .send_transaction(&mut svm, &authority.pubkey(), &[&authority])
+            .expect("pause vault should succeed");
+    }
+
+    if matches!(failure, CreateRedeemRequestFailure::PendingRequestsOverflow) {
+        set_vault_pending_async_requests(&mut svm, vault_pubkey, u16::MAX);
+    }
+
+    set_share_balance(
+        &mut svm,
+        &user_share_account,
+        &share_mint.pubkey(),
+        1_000_000,
+    );
+
+    let request_keypair = Keypair::new();
+    let result = CreateRedeemRequestBuilder::new()
+        .user(user.pubkey())
+        .asset_mint(asset_mint.pubkey())
+        .share_mint(share_mint.pubkey())
+        .request(request_keypair.pubkey())
+        .vault(vault_pubkey)
+        .user_share_account(user_share_account)
+        .share_token_program(spl_token::ID)
+        .args(RequestArgs {
+            amount: 1_000_000,
+            operator: None,
+        })
+        .instruction()
+        .send_transaction(&mut svm, &user.pubkey(), &[&user, &request_keypair]);
+
+    assert_error_code(
+        &result.unwrap_err(),
+        expected_error_code,
+        expected_error_name,
     );
 }


### PR DESCRIPTION
## Summary

Adds negative test coverage for the core request creation instructions as part of #57.

This PR covers failure paths for:

* `create_deposit_request`
* `create_redeem_request`

## Reason

Both request creation instructions rely on the same core vault invariants:

* Requests must not be created before the vault is initialized.
* Requests must not be created while the vault is paused.
* Request accounting must fail safely if `pending_async_requests` overflows.

This PR adds focused regression coverage for these protocol-level checks.

## Test

```bash
cargo test -p integration-tests async_vault::create_deposit_request:: -- --nocapture
cargo test -p integration-tests async_vault::create_redeem_request:: -- --nocapture
```

<img width="1037" height="212" alt="Screenshot 2026-06-01 at 8 08 24 PM" src="https://github.com/user-attachments/assets/bc0a0bfd-f216-4512-9722-df2378d44074" />

<img width="878" height="208" alt="Screenshot 2026-06-01 at 8 08 43 PM" src="https://github.com/user-attachments/assets/e18472eb-64e7-4501-b2b9-a1842094de1f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Enhanced async vault integration test coverage with new failure scenario tests for deposit and redeem request operations, including validation for uninitialized vaults, paused vaults, and pending request overflow conditions.
* Added test utilities to support vault state configuration in integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->