### PR TITLE
refactor(errors): single #[error_code] enum (migration PR2)

### DIFF
--- a/libs/vault_common/src/error.rs
+++ b/libs/vault_common/src/error.rs
@@ -1,94 +1,15 @@
-use anchor_lang::prelude::*;
+use thiserror::Error;
 
-#[error_code]
-pub enum VaultProgramError {
-    #[msg("The provided fee must not exceed 100% (10,000 bps).")]
-    FeeBPSLimitReached,
-
-    #[msg("The provided signer is not allowed to execute this instruction.")]
-    UnauthorizedSigner,
-
-    #[msg("Something happened while performing an arithmetic operation.")]
+/// Pure math/validation errors produced by [`crate::fee`].
+///
+/// `vault_common` deliberately carries no `#[error_code]` enum: Anchor 1.0 allows
+/// only one per program. The program crate maps these into its single
+/// `AsyncVaultError` at the call boundary.
+#[derive(Error, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VaultMathError {
+    #[error("Something happened while performing an arithmetic operation.")]
     ArithmeticError,
 
-    #[msg("The vault is paused.")]
-    PausedVault,
-
-    #[msg("The vault max asset cap has been exceeded.")]
-    MaxVaultAssetCapExceeded,
-
-    #[msg("The provided mint supply should be zero.")]
-    MintSupplyShouldBeZero,
-
-    #[msg("The provided share supply should be zero.")]
-    ShareSupplyShouldBeZero,
-
-    #[msg("The provided vault reserve should be empty in order to close it.")]
-    VaultShouldBeEmpty,
-
-    #[msg("Deposit amount too small to mint shares.")]
-    InsufficientDepositAmount,
-
-    #[msg("Initial price has to be bigger than 0")]
-    InvalidInitialPrice,
-
-    #[msg("Withdraw amount too small to burn shares.")]
-    InsufficientWithdrawAmount,
-
-    #[msg("Redeem shares amount too small.")]
-    InsufficientRedeemAmount,
-
-    #[msg("Invalid vault state for this operation.")]
-    InvalidState,
-
-    #[msg("Slippage exceeded.")]
-    SlippageExceeded,
-
-    #[msg("Vault is already initialized.")]
-    VaultAlreadyInitialized,
-
-    #[msg("The extension is already initialized.")]
-    ExtensionAlreadyInitialized,
-
-    #[msg("The vault is not initialized.")]
-    UninitializedVault,
-
-    #[msg("The extension is not initialized.")]
-    UninitializedExtension,
-
-    #[msg("The provided vault and mint mismatch.")]
-    VaultShareMintMismatch,
-
-    #[msg("The vault NAV is stale. Please update the NAV value before depositing.")]
-    StaleVaultNav,
-
-    #[msg("The provided optional account is empty.")]
-    OptionalAccountIsEmpty,
-
-    #[msg("The returned data is invalid.")]
-    InvalidReturnedData,
-
-    #[msg("The provided extra meta accounts pubkey does not match")]
-    InvalidAccountData,
-
-    #[msg("Mints should be different.")]
-    MintsShouldBeDifferent,
-
-    #[msg("Share mint supply should be zero.")]
-    ShareMintSupplyShouldBeZero,
-
-    #[msg("Async inflows are disabled, cannot deposit.")]
-    AsyncInflowsDisabled,
-
-    #[msg("Async outflows are disabled, cannot redeem.")]
-    AsyncOutflowsDisabled,
-
-    #[msg("Nav is not set.")]
-    NavIsNotSet,
-
-    #[msg("Transfer Fees are not allowed.")]
-    TransferFeesAreNotAllowed,
-
-    #[msg("Redemption yields zero assets.")]
-    ZeroAssets,
+    #[error("The provided fee must not exceed 100% (10,000 bps).")]
+    FeeBpsLimitReached,
 }

--- a/libs/vault_common/src/fee.rs
+++ b/libs/vault_common/src/fee.rs
@@ -1,5 +1,6 @@
-use crate::{constants::MAX_BPS, error::VaultProgramError};
-use anchor_lang::prelude::*;
+use anchor_lang::prelude::{borsh, AnchorDeserialize, AnchorSerialize, InitSpace};
+
+use crate::{constants::MAX_BPS, error::VaultMathError};
 
 /// The fee types:
 /// FixedAmount: a fixed fee is applied (ex 0.1 asset)
@@ -12,37 +13,36 @@ pub enum FeeType {
 
 impl FeeType {
     /// Ensures percentage fees don't exceed MAX_BPS.
-    pub fn validate(self) -> Result<()> {
-        match self {
-            FeeType::Percentage { bps } => {
-                require!(bps <= MAX_BPS, VaultProgramError::FeeBPSLimitReached);
+    pub fn validate(self) -> Result<(), VaultMathError> {
+        if let FeeType::Percentage { bps } = self {
+            if bps > MAX_BPS {
+                return Err(VaultMathError::FeeBpsLimitReached);
             }
-            FeeType::FixedAmount { .. } => {}
         }
         Ok(())
     }
 
     /// Computes the fee from a known total amount (fee-inclusive).
     /// Rounds up for percentage fees.
-    pub fn get_fee(self, total_amount: u64) -> Result<u64> {
+    pub fn get_fee(self, total_amount: u64) -> Result<u64, VaultMathError> {
         match self {
             FeeType::Percentage { bps } => {
                 let fee = total_amount
                     .checked_mul(bps.into())
-                    .ok_or(VaultProgramError::ArithmeticError)?
+                    .ok_or(VaultMathError::ArithmeticError)?
                     .checked_add(9_999)
-                    .ok_or(VaultProgramError::ArithmeticError)?
+                    .ok_or(VaultMathError::ArithmeticError)?
                     .checked_div(10_000)
-                    .ok_or(VaultProgramError::ArithmeticError)?;
-                return Ok(fee);
+                    .ok_or(VaultMathError::ArithmeticError)?;
+                Ok(fee)
             }
-            FeeType::FixedAmount { amount } => return Ok(amount),
+            FeeType::FixedAmount { amount } => Ok(amount),
         }
     }
 
     /// Back-derives the fee from the gross (fee-inclusive) withdrawal amount so the user receives
     /// net after fee.
-    pub fn get_withdraw_fee_when_redeeming(&self, gross_assets: u64) -> Result<u64> {
+    pub fn get_withdraw_fee_when_redeeming(&self, gross_assets: u64) -> Result<u64, VaultMathError> {
         match self {
             FeeType::Percentage { bps } => {
                 if *bps == 0 {
@@ -52,37 +52,37 @@ impl FeeType {
                 // Derived from: fee = net * bps / MAX_BPS where net = gross - fee
                 let denominator = u128::from(MAX_BPS)
                     .checked_add(u128::from(*bps))
-                    .ok_or(VaultProgramError::ArithmeticError)?;
+                    .ok_or(VaultMathError::ArithmeticError)?;
                 let fee = u128::from(gross_assets)
                     .checked_mul(u128::from(*bps))
-                    .ok_or(VaultProgramError::ArithmeticError)?
+                    .ok_or(VaultMathError::ArithmeticError)?
                     .div_ceil(denominator);
-                Ok(u64::try_from(fee)?)
+                u64::try_from(fee).map_err(|_| VaultMathError::ArithmeticError)
             }
             FeeType::FixedAmount { amount } => Ok(*amount),
         }
     }
 
     /// Computes the deposit fee given the desired net deposit, so gross = net + fee.
-    pub fn get_deposit_fee_when_minting(&self, net_assets: u64) -> Result<u64> {
+    pub fn get_deposit_fee_when_minting(&self, net_assets: u64) -> Result<u64, VaultMathError> {
         match self {
             FeeType::Percentage { bps } => {
                 let gross = if *bps == MAX_BPS {
                     net_assets
                         .checked_mul(2)
-                        .ok_or(VaultProgramError::ArithmeticError)?
+                        .ok_or(VaultMathError::ArithmeticError)?
                         .into()
                 } else {
                     u128::from(net_assets)
                         .checked_mul(MAX_BPS.into())
-                        .ok_or(VaultProgramError::ArithmeticError)?
+                        .ok_or(VaultMathError::ArithmeticError)?
                         .checked_div(
                             MAX_BPS
                                 .checked_sub(*bps)
-                                .ok_or(VaultProgramError::ArithmeticError)?
+                                .ok_or(VaultMathError::ArithmeticError)?
                                 .into(),
                         )
-                        .ok_or(VaultProgramError::ArithmeticError)?
+                        .ok_or(VaultMathError::ArithmeticError)?
                 };
 
                 let fee = if *bps == 0 {
@@ -90,11 +90,11 @@ impl FeeType {
                 } else {
                     gross
                         .checked_sub(u128::from(net_assets))
-                        .ok_or(VaultProgramError::ArithmeticError)?
+                        .ok_or(VaultMathError::ArithmeticError)?
                 };
-                Ok(u64::try_from(fee)?)
+                u64::try_from(fee).map_err(|_| VaultMathError::ArithmeticError)
             }
-            FeeType::FixedAmount { amount } => return Ok(*amount),
+            FeeType::FixedAmount { amount } => Ok(*amount),
         }
     }
 }

--- a/programs/async_vault/src/error.rs
+++ b/programs/async_vault/src/error.rs
@@ -74,4 +74,17 @@ pub enum AsyncVaultError {
     SubscriptionAmountBelowMinimum,
     #[msg("Redemption amount is below the minimum redemption threshold")]
     RedemptionAmountBelowMinimum,
+    #[msg("Nav is not set.")]
+    NavIsNotSet,
+    #[msg("Redeem shares amount too small.")]
+    InsufficientRedeemAmount,
+}
+
+impl From<vault_common::VaultMathError> for AsyncVaultError {
+    fn from(err: vault_common::VaultMathError) -> Self {
+        match err {
+            vault_common::VaultMathError::ArithmeticError => AsyncVaultError::ArithmeticError,
+            vault_common::VaultMathError::FeeBpsLimitReached => AsyncVaultError::FeeBpsExceeded,
+        }
+    }
 }

--- a/programs/async_vault/src/extensions/fee/instructions/initialize_deposit_fee.rs
+++ b/programs/async_vault/src/extensions/fee/instructions/initialize_deposit_fee.rs
@@ -32,7 +32,7 @@ pub struct InitDepositFee<'info> {
 }
 
 pub fn handler(ctx: Context<InitDepositFee>, args: InitDepositFeeArgs) -> Result<()> {
-    args.deposit_fee.validate()?;
+    args.deposit_fee.validate().map_err(AsyncVaultError::from)?;
     init_vault_extension(
         &ctx.accounts.vault.to_account_info(),
         &ctx.accounts.vault,

--- a/programs/async_vault/src/extensions/fee/instructions/initialize_withdrawal_fee.rs
+++ b/programs/async_vault/src/extensions/fee/instructions/initialize_withdrawal_fee.rs
@@ -32,7 +32,7 @@ pub struct InitWithdrawalFee<'info> {
 }
 
 pub fn handler(ctx: Context<InitWithdrawalFee>, args: InitWithdrawalFeeArgs) -> Result<()> {
-    args.withdrawal_fee.validate()?;
+    args.withdrawal_fee.validate().map_err(AsyncVaultError::from)?;
     init_vault_extension(
         &ctx.accounts.vault.to_account_info(),
         &ctx.accounts.vault,

--- a/programs/async_vault/src/extensions/fee/instructions/update_deposit_fee.rs
+++ b/programs/async_vault/src/extensions/fee/instructions/update_deposit_fee.rs
@@ -1,7 +1,10 @@
 use anchor_lang::prelude::*;
 use vault_common::FeeType;
 
-use crate::extensions::{fee::DepositFee, update_vault_extension, BasicExtensionAccounts};
+use crate::{
+    error::AsyncVaultError,
+    extensions::{fee::DepositFee, update_vault_extension, BasicExtensionAccounts},
+};
 
 #[derive(AnchorDeserialize, AnchorSerialize)]
 pub struct UpdateDepositFeeArgs {
@@ -9,7 +12,7 @@ pub struct UpdateDepositFeeArgs {
 }
 
 pub fn handler(ctx: Context<BasicExtensionAccounts>, args: UpdateDepositFeeArgs) -> Result<()> {
-    args.new_deposit_fee.validate()?;
+    args.new_deposit_fee.validate().map_err(AsyncVaultError::from)?;
     update_vault_extension(
         &ctx.accounts.vault.to_account_info(),
         &DepositFee::from_fee_type(args.new_deposit_fee),

--- a/programs/async_vault/src/extensions/fee/instructions/update_withdrawal_fee.rs
+++ b/programs/async_vault/src/extensions/fee/instructions/update_withdrawal_fee.rs
@@ -1,7 +1,10 @@
 use anchor_lang::prelude::*;
 use vault_common::FeeType;
 
-use crate::extensions::{fee::WithdrawalFee, update_vault_extension, BasicExtensionAccounts};
+use crate::{
+    error::AsyncVaultError,
+    extensions::{fee::WithdrawalFee, update_vault_extension, BasicExtensionAccounts},
+};
 
 #[derive(AnchorDeserialize, AnchorSerialize)]
 pub struct UpdateWithdrawalFeeArgs {
@@ -9,7 +12,7 @@ pub struct UpdateWithdrawalFeeArgs {
 }
 
 pub fn handler(ctx: Context<BasicExtensionAccounts>, args: UpdateWithdrawalFeeArgs) -> Result<()> {
-    args.new_withdrawal_fee.validate()?;
+    args.new_withdrawal_fee.validate().map_err(AsyncVaultError::from)?;
     update_vault_extension(
         &ctx.accounts.vault.to_account_info(),
         &WithdrawalFee::from_fee_type(args.new_withdrawal_fee),

--- a/programs/async_vault/src/extensions/fee/processor.rs
+++ b/programs/async_vault/src/extensions/fee/processor.rs
@@ -1,7 +1,10 @@
 use anchor_lang::prelude::*;
-use vault_common::{FeeType, VaultProgramError};
+use vault_common::FeeType;
 
-use crate::extensions::{read_vault_extension, ExtensionType};
+use crate::{
+    error::AsyncVaultError,
+    extensions::{read_vault_extension, ExtensionType},
+};
 
 /// Pod-safe representation of a fee stored in TLV:
 ///   byte 0   — discriminant (0 = FixedAmount, 1 = Percentage)
@@ -99,7 +102,7 @@ pub fn get_deposit_fee(vault_info: &AccountInfo, amount: u64) -> Result<u64> {
         .try_borrow()
         .map_err(|_| ProgramError::AccountBorrowFailed)?;
     match read_vault_extension::<DepositFee>(&data)? {
-        Some(ext) => ext.fee_type()?.get_fee(amount),
+        Some(ext) => Ok(ext.fee_type()?.get_fee(amount).map_err(AsyncVaultError::from)?),
         None => Ok(0),
     }
 }
@@ -110,7 +113,7 @@ pub fn get_withdrawal_fee(vault_info: &AccountInfo, amount: u64) -> Result<u64> 
         .try_borrow()
         .map_err(|_| ProgramError::AccountBorrowFailed)?;
     match read_vault_extension::<WithdrawalFee>(&data)? {
-        Some(ext) => ext.fee_type()?.get_fee(amount),
+        Some(ext) => Ok(ext.fee_type()?.get_fee(amount).map_err(AsyncVaultError::from)?),
         None => Ok(0),
     }
 }
@@ -119,7 +122,7 @@ pub fn get_deposit_fee_and_net(vault_info: &AccountInfo, amount: u64) -> Result<
     let fee = get_deposit_fee(vault_info, amount)?;
     let net = amount
         .checked_sub(fee)
-        .ok_or(VaultProgramError::ArithmeticError)?;
+        .ok_or(AsyncVaultError::ArithmeticError)?;
     Ok((fee, net))
 }
 
@@ -127,6 +130,6 @@ pub fn get_withdrawal_fee_and_net(vault_info: &AccountInfo, amount: u64) -> Resu
     let fee = get_withdrawal_fee(vault_info, amount)?;
     let net = amount
         .checked_sub(fee)
-        .ok_or(VaultProgramError::ArithmeticError)?;
+        .ok_or(AsyncVaultError::ArithmeticError)?;
     Ok((fee, net))
 }

--- a/programs/async_vault/src/extensions/redemption_queue/instructions/cancel_queued_redemption_request.rs
+++ b/programs/async_vault/src/extensions/redemption_queue/instructions/cancel_queued_redemption_request.rs
@@ -1,6 +1,5 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{self, Mint, MintTo, TokenAccount, TokenInterface};
-use vault_common::VaultProgramError;
 
 use crate::{
     error::AsyncVaultError,
@@ -101,7 +100,7 @@ pub fn handler(ctx: Context<CancelQueuedRedemptionRequest>) -> Result<()> {
         .vault
         .pending_async_requests
         .checked_sub(1)
-        .ok_or(VaultProgramError::ArithmeticError)?;
+        .ok_or(AsyncVaultError::ArithmeticError)?;
 
     Ok(())
 }

--- a/programs/async_vault/src/extensions/subscription_queue/instructions/cancel_queued_deposit_request.rs
+++ b/programs/async_vault/src/extensions/subscription_queue/instructions/cancel_queued_deposit_request.rs
@@ -1,6 +1,5 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{self, Mint, TokenAccount, TokenInterface, TransferChecked};
-use vault_common::VaultProgramError;
 
 use crate::{
     error::AsyncVaultError,
@@ -111,7 +110,7 @@ pub fn handler(ctx: Context<CancelQueuedDepositRequest>) -> Result<()> {
         .vault
         .pending_async_requests
         .checked_sub(1)
-        .ok_or(VaultProgramError::ArithmeticError)?;
+        .ok_or(AsyncVaultError::ArithmeticError)?;
 
     Ok(())
 }

--- a/programs/async_vault/src/instructions/approve_request.rs
+++ b/programs/async_vault/src/instructions/approve_request.rs
@@ -1,6 +1,5 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{self, Mint, TokenAccount, TokenInterface, TransferChecked};
-use vault_common::VaultProgramError;
 
 use crate::{
     error::AsyncVaultError,
@@ -134,7 +133,7 @@ pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, ApproveRequest<'info>>) ->
         matches!(ctx.accounts.request.request_state, RequestState::Pending),
         AsyncVaultError::RequestNotPending
     );
-    require!(ctx.accounts.vault.nav > 0, VaultProgramError::NavIsNotSet);
+    require!(ctx.accounts.vault.nav > 0, AsyncVaultError::NavIsNotSet);
 
     let nav = ctx.accounts.vault.nav;
     let decimals = ctx.accounts.share_mint.decimals;

--- a/programs/async_vault/src/instructions/cancel_request.rs
+++ b/programs/async_vault/src/instructions/cancel_request.rs
@@ -2,7 +2,6 @@ use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{
     self, Mint, MintTo, TokenAccount, TokenInterface, TransferChecked,
 };
-use vault_common::VaultProgramError;
 
 use crate::{
     error::AsyncVaultError,
@@ -178,7 +177,7 @@ pub fn handler(ctx: Context<CancelRequest>) -> Result<()> {
         .vault
         .pending_async_requests
         .checked_sub(1)
-        .ok_or(VaultProgramError::ArithmeticError)?;
+        .ok_or(AsyncVaultError::ArithmeticError)?;
 
     Ok(())
 }

--- a/programs/async_vault/src/instructions/create_deposit_request.rs
+++ b/programs/async_vault/src/instructions/create_deposit_request.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{self, Mint, TokenAccount, TokenInterface, TransferChecked};
-use vault_common::VaultProgramError;
 
 use crate::state::{Request, RequestState, RequestType, Vault, VAULT_CONFIG_SEED};
 
@@ -119,7 +118,7 @@ pub fn handler(ctx: Context<CreateDepositRequest>, args: RequestArgs) -> Result<
         .vault
         .pending_async_requests
         .checked_add(1)
-        .ok_or(VaultProgramError::ArithmeticError)?;
+        .ok_or(AsyncVaultError::ArithmeticError)?;
 
     // Extension: SubscriptionQueue — increment counter and tag the request with its ID.
     if let Some(id) =

--- a/programs/async_vault/src/instructions/create_redeem_request.rs
+++ b/programs/async_vault/src/instructions/create_redeem_request.rs
@@ -1,7 +1,6 @@
 use crate::error::AsyncVaultError;
 use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{self, Burn, Mint, TokenAccount, TokenInterface};
-use vault_common::VaultProgramError;
 
 use crate::{
     extensions::{
@@ -80,7 +79,7 @@ pub fn handler(ctx: Context<CreateRedeemRequest>, args: RequestArgs) -> Result<(
         args.amount,
     )?;
 
-    require!(args.amount > 0, VaultProgramError::InsufficientRedeemAmount);
+    require!(args.amount > 0, AsyncVaultError::InsufficientRedeemAmount);
 
     ctx.accounts.burn_shares(args.amount)?;
 
@@ -103,7 +102,7 @@ pub fn handler(ctx: Context<CreateRedeemRequest>, args: RequestArgs) -> Result<(
         .vault
         .pending_async_requests
         .checked_add(1)
-        .ok_or(VaultProgramError::ArithmeticError)?;
+        .ok_or(AsyncVaultError::ArithmeticError)?;
 
     // Extension: RedemptionQueue — increment counter and tag the request with its ID.
     if let Some(id) =

--- a/programs/async_vault/src/instructions/reject_request.rs
+++ b/programs/async_vault/src/instructions/reject_request.rs
@@ -2,7 +2,6 @@ use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{
     self, Mint, MintTo, TokenAccount, TokenInterface, TransferChecked,
 };
-use vault_common::VaultProgramError;
 
 use crate::{
     error::AsyncVaultError,
@@ -174,7 +173,7 @@ pub fn handler(ctx: Context<RejectRequest>) -> Result<()> {
         .vault
         .pending_async_requests
         .checked_sub(1)
-        .ok_or(VaultProgramError::ArithmeticError)?;
+        .ok_or(AsyncVaultError::ArithmeticError)?;
 
     Ok(())
 }

--- a/programs/async_vault/src/instructions/update_nav.rs
+++ b/programs/async_vault/src/instructions/update_nav.rs
@@ -1,7 +1,6 @@
 use anchor_lang::prelude::*;
-use vault_common::VaultProgramError;
 
-use crate::state::Vault;
+use crate::{error::AsyncVaultError, state::Vault};
 
 #[derive(Accounts)]
 pub struct UpdateVaultNav<'info> {
@@ -9,7 +8,7 @@ pub struct UpdateVaultNav<'info> {
 
     #[account(
         mut,
-        constraint = authority.key() == vault.authority @ VaultProgramError::UnauthorizedSigner,
+        constraint = authority.key() == vault.authority @ AsyncVaultError::UnauthorizedSigner,
     )]
     pub vault: Account<'info, Vault>,
 }
@@ -21,6 +20,6 @@ pub fn handler(ctx: Context<UpdateVaultNav>, updated_nav: u128) -> Result<()> {
         .vault
         .nav_version
         .checked_add(1)
-        .ok_or(VaultProgramError::ArithmeticError)?;
+        .ok_or(AsyncVaultError::ArithmeticError)?;
     Ok(())
 }

--- a/programs/async_vault/src/utils.rs
+++ b/programs/async_vault/src/utils.rs
@@ -3,7 +3,6 @@ use anchor_spl::token_2022::spl_token_2022::{
     self,
     extension::{BaseStateWithExtensions, StateWithExtensions},
 };
-use vault_common::VaultProgramError;
 
 use crate::error::AsyncVaultError;
 
@@ -61,13 +60,13 @@ pub fn validate_token_account_owner(info: &AccountInfo, expected_owner: &Pubkey)
 pub fn calculate_shares(nav: u128, decimals: u8, net_amount: u64) -> Result<u64> {
     let precision = 10u128
         .checked_pow(decimals as u32)
-        .ok_or(VaultProgramError::ArithmeticError)?;
+        .ok_or(AsyncVaultError::ArithmeticError)?;
     let shares = u128::from(net_amount)
         .checked_mul(precision)
-        .ok_or(VaultProgramError::ArithmeticError)?
+        .ok_or(AsyncVaultError::ArithmeticError)?
         .checked_div(nav)
-        .ok_or(VaultProgramError::ArithmeticError)?;
-    Ok(u64::try_from(shares).map_err(|_| VaultProgramError::ArithmeticError)?)
+        .ok_or(AsyncVaultError::ArithmeticError)?;
+    Ok(u64::try_from(shares).map_err(|_| AsyncVaultError::ArithmeticError)?)
 }
 
 /// Converts a share amount into assets using the supplied NAV.
@@ -76,16 +75,16 @@ pub fn calculate_shares(nav: u128, decimals: u8, net_amount: u64) -> Result<u64>
 pub fn calculate_assets(nav: u128, decimals: u8, share_amount: u64) -> Result<u64> {
     let precision = 10u128
         .checked_pow(decimals as u32)
-        .ok_or(VaultProgramError::ArithmeticError)?;
+        .ok_or(AsyncVaultError::ArithmeticError)?;
     let assets = u128::from(share_amount)
         .checked_mul(nav)
-        .ok_or(VaultProgramError::ArithmeticError)?
+        .ok_or(AsyncVaultError::ArithmeticError)?
         .checked_div(precision)
-        .ok_or(VaultProgramError::ArithmeticError)?;
+        .ok_or(AsyncVaultError::ArithmeticError)?;
     if assets.eq(&0u128) {
-        return Err(VaultProgramError::ArithmeticError.into());
+        return Err(AsyncVaultError::ArithmeticError.into());
     }
-    Ok(u64::try_from(assets).map_err(|_| VaultProgramError::ArithmeticError)?)
+    Ok(u64::try_from(assets).map_err(|_| AsyncVaultError::ArithmeticError)?)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Migration PR2 — error consolidation

Stacked on #93 (base: `migrate/anchor-1.0`). **Compiles + 43 unit tests pass on the current 0.31 toolchain** — this refactor is intentionally toolchain-independent so PR3's dep bump stays mechanical.

### Why
Anchor 1.0 disallows more than one `#[error_code]` enum per program. The repo had two used in-program: `AsyncVaultError` and `vault_common::VaultProgramError`.

### Changes
- `AsyncVaultError` is now the single `#[error_code]`; added `NavIsNotSet` + `InsufficientRedeemAmount`; replaced all 21 `VaultProgramError::*` call sites.
- `vault_common` drops `#[error_code]` → plain `thiserror` `VaultMathError` (ArithmeticError, FeeBpsLimitReached); `fee.rs` returns `Result<_, VaultMathError>`.
- Program maps `VaultMathError` → `AsyncVaultError` via `From` at the 6 fee-method boundaries (`.map_err(AsyncVaultError::from)?`).

### Note
Error codes renumber (consolidated enum) → the committed IDL + any error-code assertions update later in the stack (PR5/PR6).