### PR TITLE
feat: switch program id to vaLtx8Su1t5P1CZG5GFEMc94sN4K7A4AUUiciadtvUi

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -8,7 +8,10 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-async_vault = "2kUpRoU8oGpstygkk3ZE51upGSq9UpkjNoEUiiQ88MMY"
+async_vault = "vaLtx8Su1t5P1CZG5GFEMc94sN4K7A4AUUiciadtvUi"
+
+[programs.devnet]
+async_vault = "vaLtx8Su1t5P1CZG5GFEMc94sN4K7A4AUUiciadtvUi"
 
 [registry]
 url = "https://api.apr.dev"

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -7,9 +7,6 @@ solana_version = "3.1.14"
 resolution = true
 skip-lint = false
 
-[programs.localnet]
-async_vault = "vaLtx8Su1t5P1CZG5GFEMc94sN4K7A4AUUiciadtvUi"
-
 [programs.devnet]
 async_vault = "vaLtx8Su1t5P1CZG5GFEMc94sN4K7A4AUUiciadtvUi"
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A standard factory program for tokenized vaults on Solana, inspired by [ERC-7540
 
 For demo purposes the program is deployed on devnet.
 
-| Network | Program ID                                     |
-| ------- | ---------------------------------------------- |
+| Network | Program ID                                    |
+| ------- | --------------------------------------------- |
 | Devnet  | `vaLtx8Su1t5P1CZG5GFEMc94sN4K7A4AUUiciadtvUi` |
 
 > Not deployed to mainnet-beta.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For demo purposes the program is deployed on devnet.
 
 | Network | Program ID                                     |
 | ------- | ---------------------------------------------- |
-| Devnet  | `7M6pdteAnZmj9SEyzjsqUEqfcc4jqhpgLFF9dULDq1iP` |
+| Devnet  | `vaLtx8Su1t5P1CZG5GFEMc94sN4K7A4AUUiciadtvUi` |
 
 > Not deployed to mainnet-beta.
 

--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -1,5 +1,5 @@
 # Default program ID (async_vault). Override per deployment.
-VITE_PROGRAM_ID=7M6pdteAnZmj9SEyzjsqUEqfcc4jqhpgLFF9dULDq1iP
+VITE_PROGRAM_ID=vaLtx8Su1t5P1CZG5GFEMc94sN4K7A4AUUiciadtvUi
 
 # Default cluster the app selects on first load: solana:devnet | solana:testnet | solana:mainnet | solana:localnet
 VITE_DEFAULT_CLUSTER=solana:devnet

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -4,7 +4,7 @@ const viteEnv = import.meta.env as unknown as {
     readonly VITE_PROGRAM_ID?: string;
 };
 
-export const PROGRAM_ID_STRING: string = viteEnv.VITE_PROGRAM_ID ?? '7M6pdteAnZmj9SEyzjsqUEqfcc4jqhpgLFF9dULDq1iP';
+export const PROGRAM_ID_STRING: string = viteEnv.VITE_PROGRAM_ID ?? 'vaLtx8Su1t5P1CZG5GFEMc94sN4K7A4AUUiciadtvUi';
 export const PROGRAM_ADDRESS = PROGRAM_ID_STRING as Address;
 
 export const CLUSTER_STORAGE_KEY = 'vault-cluster';

--- a/idl/async_vault.json
+++ b/idl/async_vault.json
@@ -1,5 +1,5 @@
 {
-  "address": "2kUpRoU8oGpstygkk3ZE51upGSq9UpkjNoEUiiQ88MMY",
+  "address": "vaLtx8Su1t5P1CZG5GFEMc94sN4K7A4AUUiciadtvUi",
   "metadata": {
     "name": "async_vault",
     "version": "0.1.0",

--- a/programs/async_vault/src/lib.rs
+++ b/programs/async_vault/src/lib.rs
@@ -9,7 +9,7 @@ pub mod utils;
 use extensions::*;
 use instructions::*;
 
-declare_id!("2kUpRoU8oGpstygkk3ZE51upGSq9UpkjNoEUiiQ88MMY");
+declare_id!("vaLtx8Su1t5P1CZG5GFEMc94sN4K7A4AUUiciadtvUi");
 
 #[program]
 pub mod async_vault {


### PR DESCRIPTION
Merge once the new program is deployed 

Updates declare_id!, the IDL address, the Anchor.toml localnet/devnet entries, the deployment table in README.md, and the web app's default program ID + env example to point at the newly-deployed vanity address on devnet. The TS client's embedded address is regenerated by `pnpm run generate-clients` and is gitignored.