### PR TITLE
feat(cu): add report-only CU benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,41 @@
+name: Benchmark
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  compute-units:
+    name: Compute Units
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+        with:
+          install-anchor: 'true'
+          rust-cache-key: 'benchmark'
+
+      - name: Build IDL and clients
+        run: |
+          pnpm run generate-idl
+          pnpm run generate-clients
+
+      - name: Run benchmark
+        run: CU_REPORT=1 CU_REPORT_DATE=$(date +%Y-%m-%d) cargo test -p integration-tests
+
+      - name: Report compute units
+        uses: solana-developers/github-actions/cu-benchmark@e846103a578b3170a9a14824bcdf38d5dcf59ac0

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install-anchor: 'true'
+          install-nightly-rustfmt: 'true'
           rust-cache-key: 'benchmark'
 
       - name: Build IDL and clients

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules
 
 # Solana
 test-ledger
+**/cu_report.md
 /keypairs
 .keypairs/
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,6 +1895,7 @@ dependencies = [
  "async-vault-client",
  "borsh",
  "litesvm",
+ "serde_json",
  "solana-sdk",
  "solana-system-interface 3.2.0",
  "spl-token",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,7 @@ dependencies = [
  "anchor-lang-idl",
  "anchor-syn",
  "anyhow",
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -325,7 +325,7 @@ checksum = "32e8599d21995f68e296265aa5ab0c3cef582fd58afec014d01bd0bce18a4418"
 dependencies = [
  "anchor-lang-idl-spec",
  "anyhow",
- "heck",
+ "heck 0.3.3",
  "regex",
  "serde",
  "serde_json",
@@ -366,7 +366,7 @@ dependencies = [
  "anyhow",
  "bs58",
  "cargo_toml",
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "serde",
@@ -678,6 +678,7 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "borsh",
+ "dtor",
  "litesvm",
  "num-derive",
  "num-traits",
@@ -691,6 +692,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-rpc-client",
  "solana-sdk",
+ "tabled",
  "thiserror 2.0.18",
 ]
 
@@ -862,6 +864,12 @@ dependencies = [
  "feature-probe",
  "serde",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -1191,6 +1199,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dtor"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d738e43aa64edab57c983d56de890d65fea7dc05605490c74451ce721dfd84b"
+dependencies = [
+ "linktime-proc-macro",
 ]
 
 [[package]]
@@ -1615,6 +1632,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hmac"
@@ -2075,6 +2098,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linktime-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2345,6 +2374,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "papergrid"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,6 +2508,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit 0.23.10+spec-1.0.0",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5239,6 +5301,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "test-case"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5269,6 +5355,15 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "test-case-core",
+]
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]

--- a/clients/rust/async_vault/Cargo.toml
+++ b/clients/rust/async_vault/Cargo.toml
@@ -11,11 +11,13 @@ anchor-idl-build = ["anchor", "anchor-lang/idl-build"]
 fetch = ["dep:solana-account", "dep:solana-rpc-client"]
 serde = ["dep:serde"]
 solana-sdk = ["dep:solana-sdk"]
-litesvm = ["dep:litesvm"]
+litesvm = ["dep:litesvm", "dep:tabled", "dep:dtor"]
 
 [dependencies]
 borsh = { workspace = true, features = ["derive"] }
 litesvm = { workspace = true, optional = true }
+tabled = { version = "0.20", optional = true }
+dtor = { version = "1.0", optional = true }
 solana-address = "2.2"
 solana-account-info = "3"
 solana-cpi = "3"

--- a/clients/rust/async_vault/src/cu_tracker.rs
+++ b/clients/rust/async_vault/src/cu_tracker.rs
@@ -1,0 +1,216 @@
+//! Compute Unit (CU) tracking utilities for benchmarking instruction costs.
+//!
+//! This module provides automatic CU tracking via a global tracker when the
+//! `CU_REPORT` environment variable is set. Recording is skipped entirely
+//! when the env var is not set to save CPU cycles.
+//!
+//! # Usage
+//!
+//! Recording happens automatically when tests send transactions through the
+//! shared test helpers (gated on `CU_REPORT`); the report is written when the
+//! test binary exits. Call `record_cu` directly only for transactions sent by
+//! some other path.
+
+use std::{
+    borrow::ToOwned,
+    collections::HashMap,
+    fs::File,
+    io::Write,
+    string::{String, ToString},
+    sync::{Mutex, OnceLock},
+    vec::Vec,
+};
+
+use tabled::{settings::Style, Table, Tabled};
+
+static TRACKER: OnceLock<Mutex<CuTracker>> = OnceLock::new();
+
+/// Check if CU tracking is enabled via CU_REPORT environment variable.
+/// Caches the result to avoid repeated env lookups.
+pub fn is_tracking_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    ENABLED
+        .get_or_init(|| std::env::var("CU_REPORT").is_ok())
+        .to_owned()
+}
+
+/// Global CU tracker shared across all tests.
+fn global_tracker() -> &'static Mutex<CuTracker> {
+    TRACKER.get_or_init(|| Mutex::new(CuTracker::new()))
+}
+
+/// Record a CU measurement for a named instruction to the global tracker.
+/// Only records if the CU_REPORT environment variable is set.
+pub fn record_cu(name: &str, cus: u64) {
+    if !is_tracking_enabled() {
+        return;
+    }
+    if let Ok(mut tracker) = global_tracker().lock() {
+        tracker.record(name, cus);
+    }
+}
+
+/// Output the CU report if the CU_REPORT environment variable is set.
+/// Call this at the end of a test run to generate the markdown report.
+pub fn output_report_if_enabled() {
+    if is_tracking_enabled() {
+        if let Ok(tracker) = global_tracker().lock() {
+            tracker.print_table();
+            if let Err(e) = tracker.write_to_file("cu_report.md") {
+                eprintln!("Failed to write CU report: {}", e);
+            }
+        }
+    }
+}
+
+const MICRO_LAMPORTS: u64 = 1_000_000;
+const LAMPORTS_PER_SOL: f64 = 1_000_000_000.0;
+const BASE_FEE_LAMPORTS: u64 = 5_000;
+
+// Different rate for Microlamports per CU
+const RATE_LOW: u64 = 300;
+const RATE_MED: u64 = 40_000;
+const RATE_HIGH: u64 = 500_000;
+
+/// Calculate estimated SOL cost for a given CU amount at a specific priority rate
+fn calculate_sol_cost(cu: u64, rate: u64) -> f64 {
+    let priority_fee_micro = cu * rate;
+    let priority_fee_lamports = priority_fee_micro / MICRO_LAMPORTS;
+    let total_lamports = BASE_FEE_LAMPORTS + priority_fee_lamports;
+    total_lamports as f64 / LAMPORTS_PER_SOL
+}
+
+/// Statistics for a single instruction type (displayed in table).
+#[derive(Debug, Clone, Tabled)]
+pub struct InstructionStats {
+    #[tabled(rename = "Instruction")]
+    pub instruction: String,
+    #[tabled(rename = "Samples")]
+    pub count: usize,
+    #[tabled(rename = "CUs")]
+    pub cus: u64,
+    #[tabled(rename = "Est Cost (Low) [SOL]")]
+    pub cost_low: String,
+    #[tabled(rename = "Est Cost (Med) [SOL]")]
+    pub cost_med: String,
+    #[tabled(rename = "Est Cost (High) [SOL]")]
+    pub cost_high: String,
+}
+
+/// Tracker for collecting CU measurements across multiple instructions.
+/// Groups measurements by instruction type and computes statistics.
+#[derive(Debug)]
+pub struct CuTracker {
+    /// Maps instruction name to list of CU measurements
+    measurements: HashMap<String, Vec<u64>>,
+}
+
+impl CuTracker {
+    /// Create a new empty tracker.
+    pub fn new() -> Self {
+        Self {
+            measurements: HashMap::new(),
+        }
+    }
+
+    /// Record a CU measurement for a named instruction.
+    pub fn record(&mut self, name: &str, cus: u64) {
+        self.measurements
+            .entry(name.to_string())
+            .or_default()
+            .push(cus);
+    }
+
+    /// Get the total number of recorded measurements.
+    pub fn len(&self) -> usize {
+        self.measurements.values().map(|v| v.len()).sum()
+    }
+
+    /// Check if tracker has no measurements.
+    pub fn is_empty(&self) -> bool {
+        self.measurements.is_empty()
+    }
+
+    /// Compute statistics for each instruction type.
+    fn compute_stats(&self) -> Vec<InstructionStats> {
+        let mut stats: Vec<InstructionStats> = self
+            .measurements
+            .iter()
+            .map(|(instruction, measurements)| {
+                let count = measurements.len();
+                let cus = *measurements.iter().min().unwrap_or(&0);
+
+                let cost_low = format!("{:.9}", calculate_sol_cost(cus, RATE_LOW));
+                let cost_med = format!("{:.9}", calculate_sol_cost(cus, RATE_MED));
+                let cost_high = format!("{:.9}", calculate_sol_cost(cus, RATE_HIGH));
+
+                InstructionStats {
+                    instruction: instruction.clone(),
+                    count,
+                    cus,
+                    cost_low,
+                    cost_med,
+                    cost_high,
+                }
+            })
+            .collect();
+
+        // Sort by instruction name for consistent output
+        stats.sort_by(|a, b| a.instruction.cmp(&b.instruction));
+        stats
+    }
+
+    /// Generate a markdown-formatted report using tabled's Style::markdown().
+    pub fn to_markdown(&self) -> String {
+        if self.is_empty() {
+            return String::from("No CU measurements recorded.");
+        }
+
+        let stats = self.compute_stats();
+
+        let mut output = String::new();
+        output.push_str("# Compute Unit Report\n\n");
+        output.push_str(&Table::new(&stats).with(Style::markdown()).to_string());
+        output.push_str(&format!("\n\n*Generated: {}*\n", report_date()));
+
+        output
+    }
+
+    /// Print a formatted table to stdout.
+    pub fn print_table(&self) {
+        if self.is_empty() {
+            println!("No CU measurements recorded.");
+            return;
+        }
+
+        let stats = self.compute_stats();
+        println!("\n{}", Table::new(&stats));
+    }
+
+    /// Write the markdown report to a file.
+    pub fn write_to_file(&self, path: &str) -> std::io::Result<()> {
+        let markdown = self.to_markdown();
+        let mut file = File::create(path)?;
+        file.write_all(markdown.as_bytes())?;
+        println!("CU report written to: {}", path);
+        Ok(())
+    }
+}
+
+impl Default for CuTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Destructor that runs after all tests complete.
+/// This runs when the test binary exits, ensuring the CU report is generated
+/// after all parallel tests have finished.
+#[dtor::dtor(unsafe)]
+fn output_cu_report_on_exit() {
+    output_report_if_enabled();
+}
+
+fn report_date() -> String {
+    std::env::var("CU_REPORT_DATE").unwrap_or_default()
+}

--- a/clients/rust/async_vault/src/lib.rs
+++ b/clients/rust/async_vault/src/lib.rs
@@ -51,7 +51,10 @@ pub mod lite {
 
     /// Maps an instruction's 8-byte Anchor discriminator to a human-readable name
     /// for CU tracking. Returns None for non-vault instructions (e.g. token setup).
-    fn instruction_label(program_id: &Pubkey, data: &[u8]) -> Option<&'static str> {
+    ///
+    /// The `DISCRIMINATORS` table is kept in sync with the program IDL by the
+    /// `cu_discriminator_map_matches_idl` guard test in the integration-tests crate.
+    pub fn instruction_label(program_id: &Pubkey, data: &[u8]) -> Option<&'static str> {
         if *program_id != ASYNC_VAULT_ID || data.len() < 8 {
             return None;
         }

--- a/clients/rust/async_vault/src/lib.rs
+++ b/clients/rust/async_vault/src/lib.rs
@@ -2,6 +2,10 @@ mod generated;
 
 pub mod extensions;
 
+#[cfg(feature = "litesvm")]
+#[allow(dead_code)]
+mod cu_tracker;
+
 pub use generated::{
     accounts::*, errors::*, instructions::*, programs::*, shared, shared::*, types::*,
 };
@@ -30,14 +34,113 @@ pub mod lite {
             payer: &Pubkey,
             signers: &T,
         ) -> litesvm::types::TransactionResult {
+            let label = instruction_label(&self.program_id, &self.data);
             let tx = Transaction::new_signed_with_payer(
                 &[self],
                 Some(payer),
                 signers,
                 svm.latest_blockhash(),
             );
-            svm.send_transaction(tx)
+            let result = svm.send_transaction(tx);
+            if let (Some(name), Ok(meta)) = (label, result.as_ref()) {
+                crate::cu_tracker::record_cu(name, meta.compute_units_consumed);
+            }
+            result
         }
+    }
+
+    /// Maps an instruction's 8-byte Anchor discriminator to a human-readable name
+    /// for CU tracking. Returns None for non-vault instructions (e.g. token setup).
+    fn instruction_label(program_id: &Pubkey, data: &[u8]) -> Option<&'static str> {
+        if *program_id != ASYNC_VAULT_ID || data.len() < 8 {
+            return None;
+        }
+        let disc: [u8; 8] = data[..8].try_into().ok()?;
+        const DISCRIMINATORS: &[([u8; 8], &str)] = &[
+            (
+                ACCEPT_AUTHORITY_INVITATION_DISCRIMINATOR,
+                "accept_authority_invitation",
+            ),
+            (APPROVE_REQUEST_DISCRIMINATOR, "approve_request"),
+            (
+                CANCEL_QUEUED_DEPOSIT_REQUEST_DISCRIMINATOR,
+                "cancel_queued_deposit_request",
+            ),
+            (
+                CANCEL_QUEUED_REDEMPTION_REQUEST_DISCRIMINATOR,
+                "cancel_queued_redemption_request",
+            ),
+            (CANCEL_REQUEST_DISCRIMINATOR, "cancel_request"),
+            (CLAIM_DISCRIMINATOR, "claim"),
+            (
+                CREATE_DEPOSIT_REQUEST_DISCRIMINATOR,
+                "create_deposit_request",
+            ),
+            (CREATE_REDEEM_REQUEST_DISCRIMINATOR, "create_redeem_request"),
+            (CREATE_VAULT_DISCRIMINATOR, "create_vault"),
+            (
+                INITIALIZE_DEPOSIT_FEE_DISCRIMINATOR,
+                "initialize_deposit_fee",
+            ),
+            (
+                INITIALIZE_MIN_REDEMPTION_DISCRIMINATOR,
+                "initialize_min_redemption",
+            ),
+            (
+                INITIALIZE_MIN_SUBSCRIPTION_DISCRIMINATOR,
+                "initialize_min_subscription",
+            ),
+            (
+                INITIALIZE_PAUSABLE_REDEMPTIONS_DISCRIMINATOR,
+                "initialize_pausable_redemptions",
+            ),
+            (
+                INITIALIZE_PAUSABLE_SUBSCRIPTIONS_DISCRIMINATOR,
+                "initialize_pausable_subscriptions",
+            ),
+            (
+                INITIALIZE_REDEMPTION_QUEUE_DISCRIMINATOR,
+                "initialize_redemption_queue",
+            ),
+            (
+                INITIALIZE_SUBSCRIPTION_QUEUE_DISCRIMINATOR,
+                "initialize_subscription_queue",
+            ),
+            (INITIALIZE_VAULT_DISCRIMINATOR, "initialize_vault"),
+            (
+                INITIALIZE_WITHDRAWAL_FEE_DISCRIMINATOR,
+                "initialize_withdrawal_fee",
+            ),
+            (INVITE_NEW_AUTHORITY_DISCRIMINATOR, "invite_new_authority"),
+            (REJECT_REQUEST_DISCRIMINATOR, "reject_request"),
+            (SET_OPERATOR_DISCRIMINATOR, "set_operator"),
+            (
+                SKIP_CANCELED_QUEUE_REQUEST_DISCRIMINATOR,
+                "skip_canceled_queue_request",
+            ),
+            (UPDATE_DEPOSIT_FEE_DISCRIMINATOR, "update_deposit_fee"),
+            (UPDATE_MIN_REDEMPTION_DISCRIMINATOR, "update_min_redemption"),
+            (
+                UPDATE_MIN_SUBSCRIPTION_DISCRIMINATOR,
+                "update_min_subscription",
+            ),
+            (
+                UPDATE_PAUSABLE_REDEMPTIONS_DISCRIMINATOR,
+                "update_pausable_redemptions",
+            ),
+            (
+                UPDATE_PAUSABLE_SUBSCRIPTIONS_DISCRIMINATOR,
+                "update_pausable_subscriptions",
+            ),
+            (UPDATE_VAULT_DISCRIMINATOR, "update_vault"),
+            (UPDATE_VAULT_NAV_DISCRIMINATOR, "update_vault_nav"),
+            (UPDATE_WITHDRAWAL_FEE_DISCRIMINATOR, "update_withdrawal_fee"),
+            (WITHDRAW_ASSETS_DISCRIMINATOR, "withdraw_assets"),
+        ];
+        DISCRIMINATORS
+            .iter()
+            .find(|(d, _)| *d == disc)
+            .map(|(_, n)| *n)
     }
 }
 

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -12,3 +12,4 @@ solana-system-interface = "3"
 anchor-spl.workspace = true
 test-case.workspace = true
 spl-token.workspace = true
+serde_json = "1"

--- a/integration-tests/src/cu_map_guard.rs
+++ b/integration-tests/src/cu_map_guard.rs
@@ -1,0 +1,34 @@
+//! Guards that the CU-tracking discriminator map in the async_vault client stays
+//! in sync with the program IDL. If an instruction is added, removed, or renamed,
+//! this test fails until `DISCRIMINATORS` in `clients/rust/async_vault/src/lib.rs`
+//! is updated.
+
+use async_vault_client::{lite::instruction_label, ASYNC_VAULT_ID};
+
+#[test]
+fn cu_discriminator_map_matches_idl() {
+    let idl_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../idl/async_vault.json");
+    let raw = std::fs::read_to_string(idl_path).unwrap_or_else(|e| panic!("read {idl_path}: {e}"));
+    let idl: serde_json::Value = serde_json::from_str(&raw).expect("parse IDL");
+
+    let instructions = idl["instructions"]
+        .as_array()
+        .expect("idl.instructions array");
+    assert!(!instructions.is_empty(), "no instructions in IDL");
+
+    for ix in instructions {
+        let name = ix["name"].as_str().expect("instruction name");
+        let disc: Vec<u8> = ix["discriminator"]
+            .as_array()
+            .expect("instruction discriminator")
+            .iter()
+            .map(|b| b.as_u64().expect("discriminator byte") as u8)
+            .collect();
+
+        assert_eq!(
+            instruction_label(&ASYNC_VAULT_ID, &disc),
+            Some(name),
+            "CU discriminator map out of sync for `{name}` — update DISCRIMINATORS in clients/rust/async_vault/src/lib.rs",
+        );
+    }
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -2,3 +2,5 @@
 pub(crate) mod async_helper_functions;
 #[cfg(test)]
 mod async_vault;
+#[cfg(test)]
+mod cu_map_guard;


### PR DESCRIPTION
## Summary
- Add report-only CU benchmarking to the Anchor vault (mirrors rewards/escrow/subscriptions).
- Hook `record_cu` into the **single send chokepoint** — the litesvm `SendTransaction` impl in `clients/rust/async_vault/src/lib.rs` — so every vault instruction is captured with zero test-call-site changes. Instruction name is decoded from the 8-byte Anchor **discriminator** (map built from the generated `*_DISCRIMINATOR` constants); non-vault txs (token setup) have unknown discriminators and are skipped.
- New shared `cu_tracker` module (client crate, under the existing `litesvm` feature): in-memory global, `#[dtor]` flush on test-binary exit, gated on `CU_REPORT`, renders a `tabled` markdown `cu_report.md` with a single **Min CUs** column + SOL estimates. `tabled`/`dtor` are optional deps pulled only by the `litesvm` feature.
- New `benchmark.yml` (report-only): reuses `./.github/actions/setup` (`install-anchor`), builds via `pnpm run generate-idl && generate-clients`, runs `CU_REPORT=1 cargo test -p integration-tests`, reports via `solana-developers/github-actions/cu-benchmark`. `cu_report.md` gitignored.

## Why report-only
CU is non-deterministic across runs (on-chain ATA `find_program_address` bump search over random keypair owners), so a committed baseline would churn. Same decision as the other repos: post the table each PR, no baseline diff/commit (`commit-baseline` off; perms = `pull-requests: write`).

## Test Plan
- `pnpm run generate-clients` (from committed IDL) + `cargo check -p async-vault-client --features litesvm,solana-sdk` passes — tracker, hook, and the 31-entry discriminator map all compile against current generated constants.
- `cargo +nightly fmt --all --check` clean.
- Runtime (report generation) validates in CI; local `anchor build` is blocked by a bundled-rustc/`indexmap` toolchain mismatch unrelated to this change.

## Notes
- The discriminator→name map (31 entries) must be updated if instructions are added; unknown discriminators are silently skipped.
