### PR TITLE
docs: link Security section to Cantina audit report

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ just fmt
 
 ## Security
 
-This program has **not yet been audited**. Do not use in production.
+This program has been reviewed by [Cantina](https://cantina.xyz) (APEX). See the [audit report](audits/apex-scan-june-22-2026.pdf) and [audit status](audits/AUDIT_STATUS.md) for scope and the audited baseline commit.
+
+This remains a **reference implementation and is not audited for mainnet use** — review and audit before deploying to production.
 
 To report a vulnerability, see [SECURITY.md](SECURITY.md).
 


### PR DESCRIPTION
## Summary
- Update the README Security section to reference the Cantina (APEX) review, linking the [audit report](audits/apex-scan-june-22-2026.pdf) and [AUDIT_STATUS.md](audits/AUDIT_STATUS.md).
- Keep the reference-implementation / not-for-mainnet caution (consistent with the top-of-README banner).

Follow-up to #113.