### PR TITLE
fix(ci): restore pnpm vulnerability audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,5 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.62.1"
     },
-    "packageManager": "pnpm@10.30.0"
+    "packageManager": "pnpm@11.13.0+sha512.88d94724d8f2e6c186744a5584c6e59ecac869ec7ba15e9cb4cd628e8dc7066820b2481d8ee3b51ea8da323a7378068aa58c556a3720d32b7c20a051d088363a"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 packages:
   - clients/typescript
   - apps/web
+
+allowBuilds:
+  esbuild: true
+  unrs-resolver: true


### PR DESCRIPTION
## Summary
- Pin pnpm to 11.13.0 so `pnpm audit` uses npm's supported bulk advisory endpoint (restores the `pnpm-audit` security CI job).
- Add an `allowBuilds` policy to `pnpm-workspace.yaml` for `esbuild` and `unrs-resolver` — pnpm 11 fails install on unapproved lifecycle scripts.
- No `pnpm.overrides` to migrate; vault never defined any (unlike the subscriptions equivalent).

## Test Plan
- `corepack pnpm install --frozen-lockfile` → exit 0, both postinstalls run, no ignored-build warnings.
- `corepack pnpm audit --ignore-unfixable` → exit 0.
- `corepack pnpm --filter @solana/vault-program-web build` → builds (esbuild native binary functional).
- Lockfile unchanged (v9, pnpm 11 compatible).